### PR TITLE
Streaming indeterminately sized data sets via streaming

### DIFF
--- a/schemas/stsci.edu/finf/0.1.0/core/ndarray.yaml
+++ b/schemas/stsci.edu/finf/0.1.0/core/ndarray.yaml
@@ -98,12 +98,19 @@ properties:
         format: uri
 
   shape:
-    description: >
+    description: |
       The shape of the array.
+
+      The first entry may be the string ``*``, indicating that the
+      length of the first index of the array will be automatically
+      determined from the size of the block.  This is used for
+      streaming support.
     type: array
     items:
-      type: integer
-      minimum: 0
+      anyOf:
+        - type: integer
+          minimum: 0
+        - enum: ['*']
 
   dtype:
     description: >

--- a/source/file_layout.rst
+++ b/source/file_layout.rst
@@ -160,6 +160,9 @@ Each block begins with the following header:
   40, but may be larger, for example to align the beginning of the
   block content with a file system block boundary.
 
+- ``flags`` (32-bit unsigned integer, big-endian): A bit field
+  containing flags (described below).
+
 - ``allocated_size`` (64-bit unsigned integer, big-endian): The amount
   of space allocated for the block (not including the header), in
   bytes.
@@ -173,6 +176,16 @@ Each block begins with the following header:
 
 - ``encoding`` (16-byte character string): A way to indicate how the
   buffer is compressed or encoded.  *TBD*.
+
+Flags
+^^^^^
+
+The following bit flags are understood in the ``flags`` field:
+
+- ``STREAMED`` (0x1): When set, the block is in streaming mode, and it
+  extends to the end of the file.  When set, the ``allocated_size``
+  and ``used_size`` fields are ignored.  By necessity, any block with
+  the ``STREAMED`` bit set must be the last block in the file.
 
 Block content
 ^^^^^^^^^^^^^


### PR DESCRIPTION
FINF currently shares this shortcoming with FITS -- you can't just keep writing out rows in a table if you don't know how many there are at the beginning.  It would require updating both the block header (not so hard) and the YAML tree (potentially expensive if it requires an insertion in the file).

One possible solution is to stream to a separate BFF file (see "exploded form"), with a special mode that says "the size of the block == the size of the file", and then implode the block after the fact (or leave it external, depending on the use case).
