### PR TITLE
GWCS proposal

### DIFF
--- a/sandbox/wcs_proposal1.yaml
+++ b/sandbox/wcs_proposal1.yaml
@@ -131,11 +131,15 @@ wcs: !wcs/wcs
   # as a constant.  Here, remap_axes is used to expect three input
   # dimensions, rather than four, treating the last one as a constant
   # (rather than an axis index).
-  first_order_wcs: !transform/remap_axes
-    [0, 1, 2, !transform/constant 0]
+  first_order_wcs: !transform/serial
+    - !transform/remap_axes
+      [0, 1, 2, !transform/constant 0]
+    - *forward_wcs
 
-  second_order_wcs: !transform/remap_axes
-    [0, 1, 2, !transform/constant 1]
+  second_order_wcs: !transform/serial
+    - !transform/remap_axes
+      [0, 1, 2, !transform/constant 1]
+    - *forward_wcs
 
 #
 # Standard frame names:


### PR DESCRIPTION
This is based on the discussion on June 17 regarding dimension mapping and "stages" of a higher-level transformation.  This is just an example WCS -- it's probably fastest to just provide examples and talk about them, and then a schema can be formalized later.

It adds the concept of "steps" to the overall WCS pipeline, and removes the assumption that the transforms are always pix-to-world or world-to-pix.

One advantage of this example is that the overall structure of the transformation (which is unlikely to change for a given instrument/configuration) is separate from the specifics about the parameters on those transformations, which vary for each exposure.  It's still probably more flexible than it needs to be, since you could replace the rotation part of the linear transformation with a skew and which probably wouldn't make any sense...  One could push this idea even further and fix all of the transformation types and provide a mechanism to pass numerical values into an otherwise static structure.

The `in_map` and `out_map` feature here is a hybrid of what's in `jwst_lib.modeling` on every Model, and Erik's proposed concept of naming dimensions.  In working through the example, I didn't have a need for it outside of separable transforms.  I'm starting to wonder if it needs to exist outside of separable transforms.  Even for the case where you just want to swap axes, you can always insert a separable transform, which leads me to think we should just rename it to "axis mapper" and consider it the swiss army knife you pull out when the axes need rearranging.

Anyway, hopefully this can be something concrete around which to have concrete discussion.

@perrygreenfield, @embray, @nden, @bernie-simon
