### PR TITLE
Change github repository to asdf-standard

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Understanding JSON Schema documentation build configuration file, created by
+# ASDF Standard documentation build configuration file, created by
 # sphinx-quickstart on Thu Sep  5 10:09:57 2013.
 #
 # This file is execfile()d with the current directory set to its containing dir.

--- a/travis_deploy.sh
+++ b/travis_deploy.sh
@@ -4,7 +4,7 @@
 set -e
 
 GH_ACCOUNT=spacetelescope
-GH_REPOSITORY=understanding-json-schema
+GH_REPOSITORY=asdf-standard
 GH_REMOTE=live
 GH_PAGESBRANCH=gh-pages
 


### PR DESCRIPTION
Maybe some local directories and files defined in the Makefile as UnderstandingJSONSchema also need to be updated.

I think that this will fix the broken link to the PDF documentaiton reported in #25
