### PR TITLE
Maybe mention JSON Schema's extensibility

### DIFF
--- a/source/tree.rst
+++ b/source/tree.rst
@@ -17,10 +17,12 @@ how :ref:`n-dimensional array data
 described.  These schema are written in a language called
 :ref:`yaml-schema` which is just a thin extension of `JSON Schema,
 Draft 4
-<http://json-schema.org/latest/json-schema-validation.html>`__.
-:ref:`schema`, provides a reference to all of these schema in detail.
-:ref:`extending-asdf` describes how to use YAML schema to define new
-schema.
+<http://json-schema.org/latest/json-schema-validation.html>`__.  (Such
+extensions are allowed and even encouraged by the JSON Schema
+standard, which defines the ``$schema`` attribute as a place to
+specify which extension is being used.)  :ref:`schema`, provides a
+reference to all of these schema in detail.  :ref:`extending-asdf`
+describes how to use YAML schema to define new schema.
 
 .. _tags:
 


### PR DESCRIPTION
The "Extending ASDF" has a section introducing "YAML Schema" as a small extension to "JSON Schema"--this is certainly accurate, but I feel like it might be worth mentioning here that JSON Schema is actually _designed_ to allow this sort of extension, and that the use of the `$schema` property to point to a custom meta-schema is allowed by the standard (with the caveat that implementations are not required to understand properties defined by your extension).  

Not sure though--maybe this is too much of a technical point.  I just like it because we can say "Hey, adding on to JSON Schema to make it support YAML isn't a hack! It's a feature!"
