### PR TITLE
Add schemas for some astropy.modeling models

### DIFF
--- a/schemas/stsci.edu/asdf/0.1.0/transform/polynomial1d.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/polynomial1d.yaml
@@ -1,29 +1,44 @@
 %YAML 1.1
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "http://stsci.edu/schemas/asdf/0.1.0/transform/polynomial1d"
-tag: "tag:stsci.edu:asdf/0.1.0/transform/polynomial1d"
+id: "http://stsci.edu/schemas/asdf/0.1.0/transform/polynomial"
+tag: "tag:stsci.edu:asdf/0.1.0/transform/polynomial"
 title: >
-  A 1D polynomial transform.
+  A Polynomial model.
+
 description: >
-  1D polynomial
+  A polynomial model represented by its coefficients stored in an
+  (n+1) x (n+1) ndarray, where n is the degree of the polynomial,
+  i.e. the highest total degree of the polynomial.
+
+examples:
+  -
+    - 1D polynomial 1.2 + 0.3*x + 56.1*x**2
+    - |
+        transform: !transform/polynomial
+          coefficients: !core/ndarray
+            data: [1.2, 3.0, 2.0]
+            shape: [3]
+
+!transform/polynomial
+          !core/ndarray
+            [1.2, 0.3, 56.1]
+  -
+    - A 2D polynomial P = 1.2 + 0.3*x + 3* x*y + 2.1 * y**2
+    - |
+        !transform/polynomial
+          !core/ndarray
+            data: [[1.2, 0.0, 2.1],
+                   [0.3, 3.0, 0.0],
+                   [0.0, 0.0, 0.0]]
+            shape: [3, 3]
+
 
 type: object
 properties:
-  degree:
-    type: integer
-    description: Degree of polynomial.
-  param_dim:
-    type: integer
-  coeffs:
+  coefficients:
     description: |
-      An array with coefficients (optional)
-    anyOf:
-      - $ref: ../core/ndarray
-      - type: array
-        items:
-          type: object
-        minLength: 1
-  inverse:
-    $ref: transform
-requiredProperties: [degree]
+      An array with coefficients.
+    $ref: ../core/ndarray
+
+

--- a/schemas/stsci.edu/asdf/0.1.0/transform/polynomial1d.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/polynomial1d.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/0.1.0/transform/polynomial1d"
+tag: "tag:stsci.edu:asdf/0.1.0/transform/polynomial1d"
+title: >
+  A 1D polynomial transform.
+description: >
+  1D polynomial
+
+type: object
+properties:
+  degree:
+    type: integer
+    description: Degree of polynomial.
+  param_dim:
+    type: integer
+  coeffs:
+    description: |
+      An array with coefficients (optional)
+    anyOf:
+      - $ref: ../core/ndarray
+      - type: array
+        items:
+          type: object
+        minLength: 1
+  inverse:
+    $ref: transform
+requiredProperties: [degree]

--- a/schemas/stsci.edu/asdf/0.1.0/transform/polynomial1d.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/polynomial1d.yaml
@@ -8,34 +8,53 @@ title: >
 
 description: >
   A polynomial model represented by its coefficients stored in an
-  (n+1) x (n+1) ndarray, where n is the degree of the polynomial,
-  i.e. the highest total degree of the polynomial.
+  (n+1) x (n+1) ndarray, where n is the highest total degree of the polynomial.
+
+  .. math: P = \sum_{i=0}^{n}c_i * x^{i}
 
 examples:
   -
-    - 1D polynomial 1.2 + 0.3*x + 56.1*x**2
+    - 1D polynomial
     - |
-        transform: !transform/polynomial
-          coefficients: !core/ndarray
-            data: [1.2, 3.0, 2.0]
-            shape: [3]
+        .. math: P = 1.2 + 0.3 * x + 56.1 * x^{2}
 
-!transform/polynomial
+        !transform/polynomial
           !core/ndarray
             [1.2, 0.3, 56.1]
   -
-    - A 2D polynomial P = 1.2 + 0.3*x + 3* x*y + 2.1 * y**2
+    - A 2D polynomial
     - |
+        .. math: P = 1.2 + 0.3 * x + 3 * x * y + 2.1 * y^{2}
+
         !transform/polynomial
           !core/ndarray
-            data: [[1.2, 0.0, 2.1],
-                   [0.3, 3.0, 0.0],
-                   [0.0, 0.0, 0.0]]
-            shape: [3, 3]
+            [[1.2, 0.0, 2.1],
+             [0.3, 3.0, 0.0],
+             [0.0, 0.0, 0.0]]
+  -
+    - Two 2D polynomials, applied to two dimensions.
+    - |
+        .. math: P_x = 1.2 + 0.3 * x + 3 * x * y + 2.1 * y^{2}
+        .. math: P_y = 2 + 3 * x + 3.1 * x * y + 0.1 * x^{2}
 
+        !transform/polynomial
+          ndim: 2
+          coefficients: !core/ndarray
+                          [[1.2, 0.0, 2.1],
+                           [0.3, 3.0, 0.0],
+                           [0.0, 0.0, 0.0]],
+
+                          [[2.0, 0.0, 0,0],
+                           [3.0, 3.1, 0.0],
+                           [0.1, 0.0, 0.0]]
 
 type: object
 properties:
+  n_dims:
+    type: integer
+    default: 1
+    description: |
+      The number of dimensions.
   coefficients:
     description: |
       An array with coefficients.

--- a/schemas/stsci.edu/asdf/0.1.0/transform/rotate_celestial_to_native.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/rotate_celestial_to_native.yaml
@@ -1,0 +1,22 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/0.1.0/transforms/rotate_celestial_to_native"
+tag: "tag:stsci.edu:asdf/0.1.0/transforms/rotate_celestial_to_native"
+title: >
+  A 3D (ZXZ) rotation.
+description: >
+  Rotate coordinates from celestial to native coordinate system (WCS Paper II)
+
+type: object
+properties:
+  phi:
+    type: number
+    description: Angle, in degrees.
+  theta:
+    type: number
+    description: Angle, in degrees.
+  psi:
+    type: number
+    description: Angle, in degrees.
+requiredProperties: [phi, theta, psi]

--- a/schemas/stsci.edu/asdf/0.1.0/transform/rotate_native_to_celestial.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/rotate_native_to_celestial.yaml
@@ -1,0 +1,22 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/0.1.0/transforms/rotate_native_to_celestial"
+tag: "tag:stsci.edu:asdf/0.1.0/transforms/rotate_native_to_celestial"
+title: >
+  A 3D (ZXZ) rotation
+description: >
+  Rotate coordinates from celestial to native coordinate system (WCS Paper II)
+
+type: object
+properties:
+  phi:
+    type: number
+    description: Angle, in degrees.
+  theta:
+    type: number
+    description: Angle, in degrees.
+  psi:
+    type: number
+    description: Angle, in degrees.
+requiredProperties: [phi, theta, psi]

--- a/schemas/stsci.edu/asdf/0.1.0/transform/scale.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/scale.yaml
@@ -1,0 +1,20 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/0.1.0/transforms/scale"
+tag: "tag:stsci.edu:asdf/0.1.0/transforms/scale"
+title: >
+  A Scale model.
+description: >
+  Multiply the input by a factor
+
+type: object
+properties:
+  factor:
+    type: number
+    description: Multiplication factor.
+  param_dim:
+    type: integer
+    description:
+      Number of parameter sets.
+requiredProperties: [factor]

--- a/schemas/stsci.edu/asdf/0.1.0/transform/shift.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/shift.yaml
@@ -1,0 +1,16 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/0.1.0/wcs/rotate2d"
+tag: "tag:stsci.edu:asdf/0.1.0/wcs/rotate2d"
+title: >
+  A 2D rotation.
+description: >
+  A 2D rotation around the origin, in degrees.
+
+type: object
+properties:
+  angle:
+    type: number
+    description: Angle, in degrees.
+requiredProperties: [angle]


### PR DESCRIPTION
As I am reading through this and trying out pyasdf I tried creating schemas for `astropy.modeling` models commonly used for WCS transformations. So here they are.

I think only models which don't define an analytical inverse need the `inverse` definition in the schema so only the polynomials have it here. If this is acceptable I'll add the rest of the polynomials.