### PR TITLE
Support an `inverse` member on every transform

### DIFF
--- a/schemas/stsci.edu/asdf/0.1.0/transform/add.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/add.yaml
@@ -16,13 +16,18 @@ examples:
     - A list of transforms, performed in parallel and added together
     - |
       !transform/add
-      - !transform/generic
-        n_inputs: 1
-        n_outputs: 2
-      - !transform/generic
-        n_inputs: 1
-        n_outputs: 2
+        forward:
+          - !transform/generic
+            n_inputs: 1
+            n_outputs: 2
+          - !transform/generic
+            n_inputs: 1
+            n_outputs: 2
 
-type: array
-items:
-  $ref: transform
+allOf:
+  - $ref: transform
+  - properties:
+      forward:
+        type: array
+        items:
+          $ref: transform

--- a/schemas/stsci.edu/asdf/0.1.0/transform/affine.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/affine.yaml
@@ -1,23 +1,26 @@
 %YAML 1.1
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "http://stsci.edu/schemas/asdf/0.1.0/wcs/affine"
-tag: "tag:stsci.edu:asdf/0.1.0/wcs/affine"
+id: "http://stsci.edu/schemas/asdf/0.1.0/transform/affine"
+tag: "tag:stsci.edu:asdf/0.1.0/transform/affine"
 title: >
   An affine transform.
-description: >
-
-type: object
-properties:
-  matrix:
-    description: |
-      An affine transformation matrix of the size (*n* + 1) × (*n* +
-      1), where *n* is the number of axes in the transformation.
-    allOf:
-      - $ref: ../core/ndarray
-      - type: object
-        properties:
-          shape:
-            type: array
-            minItems: 2
-            maxItems: 2
+description: |
+  Invertability: All ASDF tools are required to be able to compute the
+  analytic inverse of this transform.
+allOf:
+  - $ref: transform
+  - type: object
+    properties:
+      matrix:
+        description: |
+          An affine transformation matrix of the size (*n* + 1) × (*n*
+          + 1), where *n* is the number of axes in the transformation.
+        allOf:
+          - $ref: ../core/ndarray
+          - type: object
+            properties:
+              shape:
+                type: array
+                minItems: 2
+                maxItems: 2

--- a/schemas/stsci.edu/asdf/0.1.0/transform/concatenate.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/concatenate.yaml
@@ -15,18 +15,27 @@ description: |
   To reorder or add/drop axes, insert ``remap_axes`` transforms in the
   subtransform list.
 
+  Invertability: All ASDF tools are required to be able to compute the
+  analytic inverse of this transform, by reversing the list of
+  transforms and applying the inverse of each.
+
 examples:
   -
     - A series of transforms
     - |
       !transform/concatenate
-      - !transform/generic
-        n_inputs: 1
-        n_outputs: 2
-      - !transform/generic
-        n_inputs: 2
-        n_outputs: 1
+        forward:
+          - !transform/generic
+            n_inputs: 1
+            n_outputs: 2
+          - !transform/generic
+            n_inputs: 2
+            n_outputs: 1
 
-type: array
-items:
-  $ref: transform
+allOf:
+  - $ref: transform
+  - properties:
+      forward:
+        type: array
+        items:
+          $ref: transform

--- a/schemas/stsci.edu/asdf/0.1.0/transform/divide.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/divide.yaml
@@ -11,19 +11,25 @@ description: |
   Each of the subtransforms must have the same number of inputs and
   outputs.
 
+  Invertability: This transform is not automatically invertible.
 examples:
   -
     - A list of transforms, performed in parallel, and then combined
       through division.
     - |
       !transform/divide
-      - !transform/generic
-        n_inputs: 1
-        n_outputs: 2
-      - !transform/generic
-        n_inputs: 1
-        n_outputs: 2
+        forward:
+          - !transform/generic
+            n_inputs: 1
+            n_outputs: 2
+          - !transform/generic
+            n_inputs: 1
+            n_outputs: 2
 
-type: array
-items:
-  $ref: transform
+allOf:
+  - $ref: transform
+  - properties:
+      forward:
+        type: array
+        items:
+          $ref: transform

--- a/schemas/stsci.edu/asdf/0.1.0/transform/generic.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/generic.yaml
@@ -1,8 +1,8 @@
 %YAML 1.1
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "http://stsci.edu/schemas/asdf/0.1.0/wcs/generic"
-tag: "tag:stsci.edu:asdf/0.1.0/wcs/generic"
+id: "http://stsci.edu/schemas/asdf/0.1.0/transform/generic"
+tag: "tag:stsci.edu:asdf/0.1.0/transform/generic"
 title: >
   A generic transform.
 description: >
@@ -10,10 +10,12 @@ description: >
   create composite models including transforms that haven't yet been
   written.  **IT WILL NOT BE IN THE FINAL VERSION OF THE SPEC**.
 
-type: object
-properties:
-  n_inputs:
-    type: integer
-  n_outputs:
-    type: integer
-requiredProperties: [n_inputs, n_outputs]
+allOf:
+  - $ref: transform
+  - type: object
+    properties:
+      n_inputs:
+        type: integer
+      n_outputs:
+        type: integer
+    requiredProperties: [n_inputs, n_outputs]

--- a/schemas/stsci.edu/asdf/0.1.0/transform/identity.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/identity.yaml
@@ -1,16 +1,19 @@
 %YAML 1.1
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "http://stsci.edu/schemas/asdf/0.1.0/wcs/identity"
-tag: "tag:stsci.edu:asdf/0.1.0/wcs/identity"
+id: "http://stsci.edu/schemas/asdf/0.1.0/transform/identity"
+tag: "tag:stsci.edu:asdf/0.1.0/transform/identity"
 title: >
   The identity transform.
 description: >
-
-type: object
-properties:
-  n_dims:
-    type: integer
-    default: 1
-    description: |
-      The number of dimensions.
+  Invertability: The inverse of this transform is also the identity
+  transform.
+allOf:
+  - $ref: transform
+  - type: object
+    properties:
+      n_dims:
+        type: integer
+        default: 1
+        description: |
+          The number of dimensions.

--- a/schemas/stsci.edu/asdf/0.1.0/transform/join.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/join.yaml
@@ -38,21 +38,28 @@ description: |
   If reordering of the input or output axes is required, use in series
   with the ``remap_axes`` transform.
 
+  Invertability: All ASDF tools are required to be able to compute the
+  analytic inverse of this transform.
 examples:
   -
     - The example in the description
     - |
       !transform/join
-      - !transform/generic
-        n_inputs: 2
-        n_outputs: 2
-      - !transform/generic
-        n_inputs: 1
-        n_outputs: 2
-      - !transform/generic
-        n_inputs: 2
-        n_outputs: 1
+        forward:
+          - !transform/generic
+            n_inputs: 2
+            n_outputs: 2
+          - !transform/generic
+            n_inputs: 1
+            n_outputs: 2
+          - !transform/generic
+            n_inputs: 2
+            n_outputs: 1
 
-type: array
-items:
-  $ref: transform
+allOf:
+  - $ref: transform
+  - properties:
+      forward:
+        type: array
+        items:
+          $ref: transform

--- a/schemas/stsci.edu/asdf/0.1.0/transform/multiply.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/multiply.yaml
@@ -11,19 +11,25 @@ description: |
   Each of the subtransforms must have the same number of inputs and
   outputs.
 
+  Invertability: This transform is not automatically invertible.
 examples:
   -
     - A list of transforms, performed in parallel, and then combined
       through multiplication.
     - |
       !transform/multiply
-      - !transform/generic
-        n_inputs: 1
-        n_outputs: 2
-      - !transform/generic
-        n_inputs: 1
-        n_outputs: 2
+        forward:
+          - !transform/generic
+            n_inputs: 1
+            n_outputs: 2
+          - !transform/generic
+            n_inputs: 1
+            n_outputs: 2
 
-type: array
-items:
-  $ref: transform
+allOf:
+  - $ref: transform
+  - properties:
+      forward:
+        type: array
+        items:
+          $ref: transform

--- a/schemas/stsci.edu/asdf/0.1.0/transform/power.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/power.yaml
@@ -11,17 +11,23 @@ description: |
   Each of the subtransforms must have the same number of inputs and
   outputs.
 
+  Invertability: This transform is not automatically invertible.
 examples:
   -
     - Take the square root of the result of a given transform.
     - |
       !transform/power
-      - !transform/generic
-        n_inputs: 1
-        n_outputs: 1
-      - !core/constant
-        0.5
+        forward:
+          - !transform/generic
+            n_inputs: 1
+            n_outputs: 1
+          - !core/constant
+            0.5
 
-type: array
-items:
-  $ref: transform
+allOf:
+  - $ref: transform
+  - properties:
+      forward:
+        type: array
+        items:
+          $ref: transform

--- a/schemas/stsci.edu/asdf/0.1.0/transform/remap_axes.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/remap_axes.yaml
@@ -24,29 +24,30 @@ description: |
   object with ``mapping`` and ``n_inputs`` properties is provided, the
   number of input axes is explicitly set by the ``n_inputs`` value.
 
+  Invertibility: TBD
 examples:
   -
     - For 2 input axes, swap the axes
     - |
         !transform/remap_axes
-          [1, 0]
+          mapping: [1, 0]
   -
     - For 2 input axes, return the second axis and drop the first
     - |
         !transform/remap_axes
-          [1]
+          mapping: [1]
 
   -
     - For 2 input axes, return the first axis twice, followed by the second
     - |
         !transform/remap_axes
-          [0, 0, 1]
+          mapping: [0, 0, 1]
 
   -
     - For 2 input axes, add a third axis which is a constant
     - |
         !transform/remap_axes
-          [0, 1, !core/constant 42]
+          mapping: [0, 1, !core/constant 42]
 
   -
     - Here we have 3 input axes, but we are explicitly dropping the last one
@@ -63,15 +64,14 @@ definitions:
         - type: integer
         - $ref: ../core/constant
 
-anyOf:
-  - $ref: "#/definitions/mapping"
-  - type: object
-    properties:
+allOf:
+  - $ref: transform
+  - properties:
       n_inputs:
         description: |
           Explicitly set the number of input axes.  If not provided,
-          it is determined from the maximum index value in the mapping
-          list.
+          it is determined from the maximum index value in the
+          mapping list.
         type: integer
       mapping:
         $ref: "#/definitions/mapping"

--- a/schemas/stsci.edu/asdf/0.1.0/transform/rotate2d.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/rotate2d.yaml
@@ -1,16 +1,20 @@
 %YAML 1.1
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "http://stsci.edu/schemas/asdf/0.1.0/wcs/rotate2d"
-tag: "tag:stsci.edu:asdf/0.1.0/wcs/rotate2d"
+id: "http://stsci.edu/schemas/asdf/0.1.0/transform/rotate2d"
+tag: "tag:stsci.edu:asdf/0.1.0/transform/rotate2d"
 title: >
   A 2D rotation.
 description: >
   A 2D rotation around the origin, in degrees.
 
-type: object
-properties:
-  angle:
-    type: number
-    description: Angle, in degrees.
-requiredProperties: [angle]
+  Invertability: All ASDF tools are required to be able to compute the
+  analytic inverse of this transform.
+allOf:
+  - $ref: transform
+  - type: object
+    properties:
+      angle:
+        type: number
+        description: Angle, in degrees.
+    requiredProperties: [angle]

--- a/schemas/stsci.edu/asdf/0.1.0/transform/subtract.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/subtract.yaml
@@ -11,19 +11,25 @@ description: |
   Each of the subtransforms must have the same number of inputs and
   outputs.
 
+  Invertability: This transform is not automatically invertible.
 examples:
   -
     - A list of transforms, performed in parallel, and then combined
       through subtraction.
     - |
       !transform/subtract
-      - !transform/generic
-        n_inputs: 1
-        n_outputs: 2
-      - !transform/generic
-        n_inputs: 1
-        n_outputs: 2
+        forward:
+          - !transform/generic
+            n_inputs: 1
+            n_outputs: 2
+          - !transform/generic
+            n_inputs: 1
+            n_outputs: 2
 
-type: array
-items:
-  $ref: transform
+allOf:
+  - $ref: transform
+  - properties:
+      forward:
+        type: array
+        items:
+          $ref: transform

--- a/schemas/stsci.edu/asdf/0.1.0/transform/tangent.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/tangent.yaml
@@ -9,10 +9,12 @@ title: |
 description: |
   Corresponds to the ``TAN`` projection in the FITS WCS standard.
 
-  TODO: Include description of math here.
+  Invertability: All ASDF tools are required to be able to compute the
+  analytic inverse of this transform.
 
-type: object
-properties:
-  direction:
-    enum: [forward, backward]
-    default: forward
+allOf:
+  - $ref: transform
+  - properties:
+      direction:
+        enum: [forward, backward]
+        default: forward

--- a/schemas/stsci.edu/asdf/0.1.0/transform/transform.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/transform.yaml
@@ -8,3 +8,18 @@ title: >
 description: >
   These objects are designed to be nested in arbitrary ways to build up
   transformation pipelines out of a number of low-level pieces.
+
+anyOf:
+  - type: object
+    properties:
+      inverse:
+        description: |
+          Explicitly sets the inverse transform of this transform.
+
+          If the transform has a direct analytic inverse, this
+          property is usually not necessary, as the ASDF-reading tool
+          can provide it automatically.
+
+        $ref: transform
+    additionalProperties: true
+  - {}

--- a/schemas/stsci.edu/asdf/0.1.0/wcs/axis.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/wcs/axis.yaml
@@ -104,7 +104,7 @@ properties:
 
   name:
     description: |
-      The name of the axis.  If the `type` is multidimensional, such
+      The name of the axis.  If the ``type`` is multidimensional, such
       as "celestial", this name has meaning, and must correspond to
       it.  For example, for a celestial ICRS frame, it must be either
       "ra" or "dec".  Otherwise, it may be an arbitrary name for the

--- a/schemas/stsci.edu/asdf/0.1.0/wcs/wcs.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/wcs/wcs.yaml
@@ -14,7 +14,7 @@ examples:
     - A complex example where...
     - |
       !wcs/wcs
-        forward: !wcs/steps
+        transform: !wcs/steps
           - !wcs/step
             # Name is the name for the step.  This will allow for an
             # API to say "transform from pixel to focal_plane".  These
@@ -42,8 +42,10 @@ examples:
                 name: order
 
             transform: !transform/concatenate
-              - !transform/remap_axes [1, 0, 2, 3]
+              - !transform/remap_axes
+                mapping: [1, 0, 2, 3]
               - !transform/join
+                forward:
                 - !transform/generic
                   n_inputs: 3
                   n_outputs: 3
@@ -76,7 +78,8 @@ examples:
             # spectral_with_order takes (order, lambda) as inputs, so
             # we swap them first
             - !transform/concatenate  # in 2 --> out 1
-              - !transform/remap_axes [1, 0]
+              - !transform/remap_axes
+                mapping: [1, 0]
               - !transform/generic
                 n_inputs: 2
                 n_outputs: 1
@@ -102,28 +105,19 @@ examples:
                 name: lambda
                 unit: !unit/unit Hz
 
-allOf:
-  - type: object
-    properties:
-      forward:
-        description: |
-          The forward transformation, usually from detector to world
-          coordinates.
+type: object
+properties:
+  transform:
+    description: |
+      A list of steps in the forward transformation from detector to
+      world coordinates.
 
-          If not provided, a ASDF tool may automatically determine it
-          by inverting the backward transformation, if possible.
-        $ref: steps
+      The inverse transformation is determined automatically by
+      reversing this list, and inverting each of the individual
+      transforms according to the rules described in :ref:`inverse
+      <http://stsci.edu/schemas/asdf/0.1.0/transform/transform/anyOf/0/properties/inverse>`.
 
-      backward:
-        description: |
-          The transformation from world to pixel coordinates.
+    $ref: steps
 
-          If not provided, a ASDF tool may automatically determine it
-          by inverting the forward transformation, if possible.
-        $ref: steps
-
-    minProperties: 1
-    additionalProperties: false
-
-  - type: object
-    additionalProperties: true
+required: [transform]
+additionalProperties: false

--- a/source/extending.rst
+++ b/source/extending.rst
@@ -44,7 +44,8 @@ schema` includes::
       data:
         $ref: "ndarray"
 
-And the `ndarray` schema includes::
+And the :ref:`ndarray
+<http://stsci.edu/schemas/asdf/0.1.0/core/ndarray>` schema includes::
 
     tag: "tag:stsci.edu:asdf/0.1.0/core/ndarray"
 


### PR DESCRIPTION
This is defined in the base class "transform", so is therefore available on every transform.

The unfortunate fallout of this is that all transforms must be dictionaries (object in JSON-speak), in order to have an `inverse` property.  So the transforms that were just lists of things now have to be dictionaries with a property whose value is a list.  Makes things more verbose, but I couldn't really see a better way around it other than special-casing those and allowing either (dictionary only if you _need_ to have an inverse), but that just seemed confusing from a user API level.

@nden, @embray
