### PR TITLE
add polynomial schemas

### DIFF
--- a/schemas/stsci.edu/asdf/0.1.0/transform/polynomial.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/polynomial.yaml
@@ -1,0 +1,42 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/0.1.0/transform/polynomial"
+tag: "tag:stsci.edu:asdf/0.1.0/transform/polynomial"
+title: >
+  A Polynomial model.
+
+description: |
+  A polynomial model represented by its coefficients stored in
+  an ndarray of shape ``(n+1,)`` for univariate polynomials or ``(n+1, n+1)``
+  for polynomials with 2 variables, where ``n`` is the highest total degree
+  of the polynomial.
+
+  :math:`P = \sum_{i, j=0}^{i+j=n}c_{ij} * x^{i} * y^{j}`
+
+  Invertability: This transform is not automatically invertible.
+
+examples:
+  -
+    - :math:`P = 1.2 + 0.3 * x + 56.1 * x^{2}`
+    - |
+        !transform/polynomial
+          !core/ndarray
+          [1.2, 0.3, 56.1]
+  -
+    - :math:`P = 1.2 + 0.3 * x + 3 * x * y + 2.1 * y^{2}`
+    - |
+        !transform/polynomial
+          !core/ndarray
+          [[1.2, 0.0, 2.1],
+          [0.3, 3.0, 0.0],
+          [0.0, 0.0, 0.0]]
+
+type: object
+properties:
+  coefficients:
+    description: |
+      An array with coefficients.
+    $ref: ../core/ndarray
+required: [coefficients]
+

--- a/schemas/stsci.edu/asdf/0.1.0/transform/polynomial.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/polynomial.yaml
@@ -21,22 +21,24 @@ examples:
     - :math:`P = 1.2 + 0.3 * x + 56.1 * x^{2}`
     - |
         !transform/polynomial
-          !core/ndarray
-          [1.2, 0.3, 56.1]
+          coefficients: !core/ndarray
+                          [1.2, 0.3, 56.1]
   -
     - :math:`P = 1.2 + 0.3 * x + 3 * x * y + 2.1 * y^{2}`
     - |
         !transform/polynomial
-          !core/ndarray
-          [[1.2, 0.0, 2.1],
-          [0.3, 3.0, 0.0],
-          [0.0, 0.0, 0.0]]
+          coefficients: !core/ndarray
+                          [[1.2, 0.0, 2.1],
+                           [0.3, 3.0, 0.0],
+                           [0.0, 0.0, 0.0]]
 
 type: object
 properties:
   coefficients:
     description: |
       An array with coefficients.
-    $ref: ../core/ndarray
+    anyOf:
+      - $ref: ../core/ndarray
+      - type: array
 required: [coefficients]
 

--- a/schemas/stsci.edu/asdf/0.1.0/transform/scale.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/scale.yaml
@@ -1,0 +1,16 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/0.1.0/transform/scale"
+tag: "tag:stsci.edu:asdf/0.1.0/transform/scale"
+title: >
+  A Scale model.
+description: >
+  Multiply the input by a factor.
+
+type: object
+properties:
+  factor:
+    type: number
+    description: Multiplication factor.
+requiredProperties: [factor]

--- a/schemas/stsci.edu/asdf/0.1.0/transform/shift.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/shift.yaml
@@ -1,0 +1,16 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/0.1.0/transform/shift"
+tag: "tag:stsci.edu:asdf/0.1.0/transform/shift"
+title: >
+  A Shift opeartion.
+description: >
+  Apply an offset in one direction.
+
+type: object
+properties:
+  offset:
+    type: number
+    description: Offset in one direction.
+requiredProperties: [offset]

--- a/source/conf.py
+++ b/source/conf.py
@@ -27,6 +27,7 @@ import sphinx_bootstrap_theme
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
+mathjax_path="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
 extensions = ['sphinx.ext.mathjax', 'sphinx.ext.ifconfig', 'sphinxext.category']
 
 # Add any paths that contain templates here, relative to this directory.

--- a/source/schemas/transform.rst
+++ b/source/schemas/transform.rst
@@ -41,6 +41,15 @@ Arithmetic operations
    stsci.edu/asdf/0.1.0/transform/divide.rst
    stsci.edu/asdf/0.1.0/transform/power.rst
 
+Simple Transforms
+-----------------
+
+.. toctree::
+   :maxdepth: 1
+
+   stsci.edu/asdf/0.1.0/transform/shift.rst
+   stsci.edu/asdf/0.1.0/transform/scale.rst
+
 Projections
 -----------
 
@@ -58,5 +67,4 @@ Polynomials
    :maxdepth: 1
 
    stsci.edu/asdf/0.1.0/transform/polynomial.rst
-   stsci.edu/asdf/0.1.0/transform/shift.rst
-   stsci.edu/asdf/0.1.0/transform/scale.rst
+

--- a/source/schemas/transform.rst
+++ b/source/schemas/transform.rst
@@ -50,3 +50,13 @@ Projections
    stsci.edu/asdf/0.1.0/transform/affine.rst
    stsci.edu/asdf/0.1.0/transform/rotate2d.rst
    stsci.edu/asdf/0.1.0/transform/tangent.rst
+
+Polynomials
+-----------
+
+.. toctree::
+   :maxdepth: 1
+
+   stsci.edu/asdf/0.1.0/transform/polynomial.rst
+   stsci.edu/asdf/0.1.0/transform/shift.rst
+   stsci.edu/asdf/0.1.0/transform/scale.rst


### PR DESCRIPTION
This PR adds schemas for polynomials implemented in modeling.
After playing with these for a while I'm in favor of not dealing with multiple polynomials as implemented in modeling and keep it as general as possible. If this approach is accepted I'll create schemas for the rest of the polynomials. I will also submit a PR implementing these in pyasdf shortly.
@mdboom