### PR TITLE
Add domain on transforms

### DIFF
--- a/schemas/stsci.edu/asdf/0.1.0/transform/domain.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/domain.yaml
@@ -21,12 +21,18 @@ examples:
 
 properties:
   lower:
-    description: The lower value of the domain.
+    description: >
+      The lower value of the domain.  If not provided, the
+      domain has no lower limit.
     type: number
+    default: -inf
 
   upper:
-    description: The upper value of the domain.
+    description: >
+      The upper value of the domain.  If not provided, the
+      domain has no upper limit.
     type: number
+    default: inf
 
   includes_lower:
     description: If `true`, the domain includes `lower`.

--- a/schemas/stsci.edu/asdf/0.1.0/transform/domain.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/domain.yaml
@@ -2,7 +2,7 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/0.1.0/transform/domain"
-tag: "tag:stsci.edu:asdf/0.1.0/transform/add"
+tag: "tag:stsci.edu:asdf/0.1.0/transform/domain"
 title: >
   Defines the domain of an input axis.
 

--- a/schemas/stsci.edu/asdf/0.1.0/transform/domain.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/domain.yaml
@@ -1,0 +1,39 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/0.1.0/transform/domain"
+tag: "tag:stsci.edu:asdf/0.1.0/transform/add"
+title: >
+  Defines the domain of an input axis.
+
+description: >
+  Describes the range of acceptable input values to a particular
+  axis of a transform.
+
+examples:
+  -
+    - The domain ``[0, 1)``.
+    - |
+      !transform/domain
+        lower: 0
+        upper: 1
+        includes_lower: true
+
+properties:
+  lower:
+    description: The lower value of the domain.
+    type: number
+
+  upper:
+    description: The upper value of the domain.
+    type: number
+
+  includes_lower:
+    description: If `true`, the domain includes `lower`.
+    type: boolean
+    default: false
+
+  includes_upper:
+    description: If `true`, the domain includes `upper`.
+    type: boolean
+    default: false

--- a/schemas/stsci.edu/asdf/0.1.0/transform/transform.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/transform.yaml
@@ -16,6 +16,15 @@ anyOf:
         description: |
           A user-friendly name for the transform, to give it extra
           meaning.
+
+      domain:
+        description: |
+          The domain (range of valid inputs) to the transform.
+          Each entry in the list corresponds to an input dimension.
+        type: array
+        items:
+          $ref: domain
+
       inverse:
         description: |
           Explicitly sets the inverse transform of this transform.


### PR DESCRIPTION
This adds a `domain` key to all transforms.

@nden: If this makes sense to you, I'll go ahead and add an implementation in pyasdf (which would just stuff the information in `meta.domain` until `astropy.modeling` grows support for this).