### PR TITLE
Markdown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
     - master
 
 before_install:
-  - pip install six sphinx sphinx_bootstrap_theme jsonschema pyyaml
+  - pip install six sphinx sphinx_bootstrap_theme jsonschema pyyaml mistune
   - bash -x ./install-texlive.sh
   - export PATH=$PWD/texlive/bin/x86_64-linux:$PATH
 

--- a/README.md
+++ b/README.md
@@ -3,3 +3,16 @@ ASDF standard
 
 This document describes the Advanced Scientific Data Format (ASDF),
 pronounced *AZ*-diff.
+
+Build requirements
+==================
+
+- `sphinx`
+- `sphinx_bootstrap_theme`
+- `jsonschema`
+- `pyyaml`
+- `mistune`
+
+The following command should install these requirements::
+
+  pip install sphinx sphinx_bootstrap_theme jsonshema pyyaml mistune

--- a/convert_schemas.py
+++ b/convert_schemas.py
@@ -14,6 +14,8 @@ import textwrap
 
 import yaml
 
+from md2rst import md2rst
+
 
 def write_if_different(filename, data):
     """ Write `data` to `filename`, if the content of the file is different.
@@ -243,11 +245,6 @@ def reindent(content, indent):
     return '\n'.join(lines)
 
 
-def write_subschemas(o, name, schema, path, level, schemas):
-    indent = '  ' * max(level, 0)
-
-
-
 def recurse(o, name, schema, path, level, required=False):
     """
     Convert a schema fragment to reStructuredText.
@@ -291,10 +288,10 @@ def recurse(o, name, schema, path, level, required=False):
         o.write(' Required.')
     o.write('\n\n')
 
-    o.write(reindent(schema.get('title', ''), indent))
+    o.write(reindent(md2rst(schema.get('title', '')), indent))
     o.write('\n\n')
 
-    o.write(reindent(schema.get('description', ''), indent))
+    o.write(reindent(md2rst(schema.get('description', '')), indent))
     o.write('\n\n')
 
     if 'default' in schema:
@@ -344,7 +341,7 @@ def recurse(o, name, schema, path, level, required=False):
         o.write(indent)
         o.write(":category:`Examples:`\n\n")
         for description, example in schema['examples']:
-            o.write(reindent(description + "::\n\n", indent))
+            o.write(reindent(md2rst(description + "::\n\n"), indent))
             o.write(reindent(example, indent + '  '))
             o.write('\n\n')
 

--- a/md2rst.py
+++ b/md2rst.py
@@ -1,0 +1,195 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+"""
+Implements a markdown to reST converter using the mistune markdown
+parser.
+"""
+
+import re
+import textwrap
+
+import mistune
+
+
+class BlockLexer(mistune.BlockLexer):
+    # Adds math support
+
+    def __init__(self, *args, **kwargs):
+        super(BlockLexer, self).__init__(*args, **kwargs)
+        self.enable_math()
+
+    def enable_math(self):
+        self.rules.block_math = re.compile(r'^\$\$(.*?)\$\$', re.DOTALL)
+        self.default_rules = ['block_math'] + mistune.BlockLexer.default_rules
+
+    def parse_block_math(self, m):
+        self.tokens.append({
+            'type': 'block_math',
+            'text': m.group(1)
+        })
+
+
+class Markdown(mistune.Markdown):
+    def output_block_math(self):
+        return self.renderer.block_math(self.token['text'])
+
+
+class InlineLexer(mistune.InlineLexer):
+    # Adds math support
+
+    default_rules = ['math'] + mistune.InlineLexer.default_rules
+
+    def __init__(self, *args, **kwargs):
+        super(InlineLexer, self).__init__(*args, **kwargs)
+        self.enable_math()
+
+    def enable_math(self):
+        self.rules.text = re.compile(
+            r'^[\s\S]+?(?=[\\<!\[_*`~$]|https?://| {2,}\n|$)')
+        self.rules.math = re.compile(r'^\$(.+?)\$')
+        self.default_rules = ['math'] + mistune.InlineLexer.default_rules
+
+    def output_math(self, m):
+        return self.renderer.math(m.group(1))
+
+
+class RstRenderer(object):
+    """The default HTML renderer for rendering Markdown.
+    """
+    def __init__(self, **kwargs):
+        self.options = kwargs
+        self.levels = kwargs.get('levels', '*=-^"+:~')
+
+    def _indented(self, content):
+        content = textwrap.dedent(content)
+        return '\n'.join('   ' + line for line in content.split('\n'))
+
+    def _directive(self, name, content, args=[], attributes={}):
+        out = '.. %s:: %s\n' % (name, ', '.join(args))
+        for key, val in attributes.items():
+            out += '    :%s: %s\n' % (key, val)
+        out += '\n'
+        out += self._indented(content)
+        out += '\n\n'
+        return out
+
+    def placeholder(self):
+        return ''
+
+    def block_code(self, code, lang=None):
+        code = code.rstrip('\n')
+        if lang:
+            langs = lang
+        else:
+            langs = []
+        return self._directive('code', code, langs)
+
+    def block_quote(self, text):
+        return self._indented(text)
+
+    def block_html(self, html):
+        if self.options.get('skip_html'):
+            return ''
+        return self._directive('raw', html, ['html'])
+
+    def header(self, text, level, raw=None):
+        return '%s\n%s\n\n' % (text, self.levels[level] * len(text))
+
+    def hrule(self):
+        return '\n\n--------\n\n'
+
+    def list(self, body, ordered=True):
+        if ordered:
+            body = ('\n' + body).replace('\n- ', '\n#.')
+        return body
+
+    def list_item(self, text):
+        return textwrap.fill(
+            text, initial_indent='-  ', subsequent_indent='   ') + '\n\n'
+
+    def paragraph(self, text):
+        return '%s\n\n' % text
+
+    def table(self, header, body):
+        raise NotImplementedError()
+
+    def table_row(self, content):
+        raise NotImplementedError()
+
+    def table_cell(self, content, **flags):
+        raise NotImplementedError()
+
+    def double_emphasis(self, text):
+        return '**%s**' % text
+
+    def emphasis(self, text):
+        return '*%s*' % text
+
+    def codespan(self, text):
+        return ':code:`%s`' % text
+
+    def linebreak(self):
+        return ''
+
+    def strikethrough(self, text):
+        return text
+
+    def text(self, text):
+        return text
+
+    def autolink(self, link, is_email=False):
+        text = link
+        if is_email:
+            link = 'mailto:%s' % link
+        if link.startswith('ref:'):
+            return ':ref:`%s <%s>`' % (text, link[4:])
+        return '`%s <%s>`__' % (text, link)
+
+    def link(self, link, title, text):
+        if link.startswith('javascript:'):
+            link = ''
+        if link.startswith('ref:'):
+            return ':ref:`%s <%s>`' % (text, link[4:])
+        return '`%s <%s>`__' % (text, link)
+
+    def image(self, src, title, text):
+        if src.startswith('javascript:'):
+            src = ''
+        options = {}
+        if text:
+            options['alt'] = text
+        return self._directive('image', '', [src], options)
+
+    def tag(self, html):
+        if self.options.get('skip_html'):
+            return ''
+        return ":raw:`%s`" % html
+
+    def newline(self):
+        return ''
+
+    def footnote_ref(self, key, index):
+        raise NotImplementedError()
+
+    def footnote_item(self, key, text):
+        raise NotImplementedError()
+
+    def footnotes(self, text):
+        raise NotImplementedError()
+
+    def math(self, text):
+        return ':math:`%s`' % text
+
+    def block_math(self, text):
+        return self._directive('math', text)
+
+
+def md2rst(content):
+    """
+    Convert the given string in markdown to a string of reST.
+    """
+    renderer = RstRenderer()
+    md = Markdown(
+        block=BlockLexer, inline=InlineLexer, renderer=renderer)
+    return md.render(content)

--- a/schemas/stsci.edu/asdf/0.1.0/core/complex.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/core/complex.yaml
@@ -4,13 +4,15 @@ $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/0.1.0/core/complex"
 title: Complex number value.
 description: |
-  Represents a complex number matching the following EBNF grammar::
+  Represents a complex number matching the following EBNF grammar
 
+  ```
     plus-or-minus = "+" | "-"
     suffix        = "J" | "j" | "I" | "i"
     complex       = [ieee754] [plus-or-minus ieee754 suffix]
+  ```
 
-  Where ``ieee754`` is a floating point number in IEEE 754 decimal
+  Where `ieee754` is a floating point number in IEEE 754 decimal
   format.
 
 examples:

--- a/schemas/stsci.edu/asdf/0.1.0/core/ndarray.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/core/ndarray.yaml
@@ -18,7 +18,7 @@ description: |
     ``data`` property, in which case it is possible to explicitly
     specify the ``datatype`` and other properties.
 
-  - External to the tree: The data comes from a :ref:`block <block>`
+  - External to the tree: The data comes from a [block](ref:block)
     within the same ASDF file or an external ASDF file referenced by a
     URI.
 
@@ -85,8 +85,8 @@ examples:
           offset: 2099200
 
   -
-    - A table datatype, with nested columns for a coordinate in (ra,
-      dec), and a 3x3 convolution kernel
+    - A table datatype, with nested columns for a coordinate in (*ra*,
+      *dec*), and a 3x3 convolution kernel
     - |
         !core/ndarray
           source: 0
@@ -154,23 +154,23 @@ definitions:
 
       There is a set of numeric types, each with a single identifier:
 
-      - ``int8``, ``int16``, ``int32``, ``int64``: Signed integer
-        types, with the given bit size.
+      - `int8`, `int16`, `int32`, `int64`: Signed integer types, with
+        the given bit size.
 
-      - ``uint8``, ``uint16``, ``uint32``, ``uint64``: Unsigned
-        integer types, with the given bit size.
+      - `uint8`, `uint16`, `uint32`, `uint64`: Unsigned integer types,
+        with the given bit size.
 
-      - ``float32``: Single-precision floating-point type or
-        "binary32", as defined in IEEE 754.
+      - `float32`: Single-precision floating-point type or "binary32",
+        as defined in IEEE 754.
 
-      - ``float64``: Double-precision floating-point type or
-        "binary64", as defined in IEEE 754.
+      - `float64`: Double-precision floating-point type or "binary64",
+        as defined in IEEE 754.
 
-      - ``complex64``: Complex number where the real and imaginary
-        parts are each single-precision floating-point ("binary32")
-        numbers, as defined in IEEE 754.
+      - `complex64`: Complex number where the real and imaginary parts
+        are each single-precision floating-point ("binary32") numbers,
+        as defined in IEEE 754.
 
-      - ``complex128``: Complex number where the real and imaginary
+      - `complex128`: Complex number where the real and imaginary
         parts are each double-precision floating-point ("binary64")
         numbers, as defined in IEEE 754.
 
@@ -178,10 +178,10 @@ definitions:
       be indicated with a 2-element array where the first element is an
       identifier for the string type, and the second is a length:
 
-      - ``ascii``: A string containing ASCII text (all codepoints < 128),
-        where each character is 1 byte.
+      - `ascii`: A string containing ASCII text (all codepoints <
+        128), where each character is 1 byte.
 
-      - ``ucs4``: A string containing unicode text in the UCS-4
+      - `ucs4`: A string containing unicode text in the UCS-4
         encoding, where each character is always 4 bytes long.  Here
         the number of bytes used is 4 times the given length.
 
@@ -240,20 +240,20 @@ definitions:
       homogeneous arrays, not tables.
 
       - If any of the elements in the array are YAML strings, the
-        ``datatype`` of the entire array is ``ucs4``, with the width
-        of the largest string in the column, otherwise...
+        `datatype` of the entire array is `ucs4`, with the width of
+        the largest string in the column, otherwise...
 
       - If any of the elements in the array are complex numbers, the
-        ``datatype`` of the entire column is ``complex128``, otherwise...
+        `datatype` of the entire column is `complex128`, otherwise...
 
       - If any of the types in the column are numbers with a decimal
-        point, the ``datatype`` of the entire column is ``float64``,
+        point, the `datatype` of the entire column is `float64`,
         otherwise..
 
-      - If any of the types in the column are integers, the ``datatype``
-        of the entire column is ``int64``, otherwise...
+      - If any of the types in the column are integers, the `datatype`
+        of the entire column is `int64`, otherwise...
 
-      - The ``datatype`` of the entire column is ``bool8``.
+      - The `datatype` of the entire column is `bool8`.
 
     type: array
     items:
@@ -273,25 +273,23 @@ anyOf:
         description: |
           The source of the data.
 
-          - If an integer:
-
-              - If positive, the zero-based index of the block within the
-                same file.
-
-              - If negative, the index from the last block within the same
-                file.  For example, a source of ``-1`` corresponds to the
-                last block in the same file.
+          - If an integer: If positive, the zero-based index of the
+            block within the same file. If negative, the index from
+            the last block within the same file.  For example, a
+            source of `-1` corresponds to the last block in the same
+            file.
 
           - If a string, a URI to an external ASDF file containing the
             block data.  Relative URIs and ``file:`` and ``http:``
             protocols must be supported.  Other protocols may be supported
             by specific library implementations.
 
-            The ability to reference block data in an external ASDF file
-            is intentionally limited to the first block in the external
-            ASDF file, and is intended only to support the needs of
-            :ref:`exploded`.  For the more general case of referencing
-            data in an external ASDF file, use tree :ref:`references`.
+          The ability to reference block data in an external ASDF file
+          is intentionally limited to the first block in the external
+          ASDF file, and is intended only to support the needs of
+          [exploded](ref:exploded).  For the more general case of
+          referencing data in an external ASDF file, use tree
+          [references](ref:references).
 
         anyOf:
           - type: integer
@@ -302,17 +300,17 @@ anyOf:
         description: |
           The data for the array inline.
 
-          If ``datatype`` and/or ``shape`` are also provided, they must
+          If `datatype` and/or `shape` are also provided, they must
           match the data here and can be used as a consistency check.
-          ``strides``, ``offset`` and ``byteorder`` are meaningless
-          when ``data`` is provided.
+          `strides`, `offset` and `byteorder` are meaningless when
+          `data` is provided.
         $ref: "#/definitions/inline-data"
 
       shape:
         description: |
           The shape of the array.
 
-          The first entry may be the string ``*``, indicating that the
+          The first entry may be the string `*`, indicating that the
           length of the first index of the array will be automatically
           determined from the size of the block.  This is used for
           streaming support.

--- a/schemas/stsci.edu/asdf/0.1.0/fits/fits.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/fits/fits.yaml
@@ -11,7 +11,7 @@ description: |
 
   Not all kinds of data in FITS are directly representable in ASDF.
   For example, applying an offset and scale to the data using the
-  ``BZERO`` and ``BSCALE`` keywords.  In these cases, it will not be
+  `BZERO` and `BSCALE` keywords.  In these cases, it will not be
   possible to store the data in the native format from FITS and also
   be accessible in its proper form in the ASDF file.
 examples:

--- a/schemas/stsci.edu/asdf/0.1.0/transform/compose.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/compose.yaml
@@ -12,7 +12,7 @@ description: |
 
   The number of output dimensions of each subtransform must be equal
   to the number of input dimensions of the next subtransform in list.
-  To reorder or add/drop axes, insert ``remap_axes`` transforms in the
+  To reorder or add/drop axes, insert `remap_axes` transforms in the
   subtransform list.
 
   Invertability: All ASDF tools are required to be able to compute the

--- a/schemas/stsci.edu/asdf/0.1.0/transform/concatenate.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/concatenate.yaml
@@ -21,12 +21,13 @@ description: |
   For example, given 5 input axes, and 3 subtransforms with the
   following orders:
 
-  - transform A: 2 in -> 2 out
-  - transform B: 1 in -> 2 out
-  - transform C: 2 in -> 1 out
+  1. transform A: 2 in -> 2 out
+  1. transform B: 1 in -> 2 out
+  1. transform C: 2 in -> 1 out
 
-  The transform is performed as follows::
+  The transform is performed as follows:
 
+  ```
     :    i0    i1       i2       i3    i4
     :    |     |        |        |     |
     :  +---------+ +---------+ +----------+
@@ -34,9 +35,10 @@ description: |
     :  +---------+ +---------+ +----------+
     :    |     |     |     |        |
     :    o0    o1    o2    o3       o4
+  ```
 
   If reordering of the input or output axes is required, use in series
-  with the ``remap_axes`` transform.
+  with the `remap_axes` transform.
 
   Invertability: All ASDF tools are required to be able to compute the
   analytic inverse of this transform.

--- a/schemas/stsci.edu/asdf/0.1.0/transform/domain.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/domain.yaml
@@ -12,7 +12,7 @@ description: >
 
 examples:
   -
-    - The domain ``[0, 1)``.
+    - The domain `[0, 1)`.
     - |
       !transform/domain
         lower: 0

--- a/schemas/stsci.edu/asdf/0.1.0/transform/polynomial.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/polynomial.yaml
@@ -8,23 +8,23 @@ title: >
 
 description: |
   A polynomial model represented by its coefficients stored in
-  an ndarray of shape ``(n+1,)`` for univariate polynomials or ``(n+1, n+1)``
-  for polynomials with 2 variables, where ``n`` is the highest total degree
+  an ndarray of shape $(n+1)$ for univariate polynomials or $(n+1, n+1)$
+  for polynomials with 2 variables, where $n$ is the highest total degree
   of the polynomial.
 
-  :math:`P = \sum_{i, j=0}^{i+j=n}c_{ij} * x^{i} * y^{j}`
+  $$P = \sum_{i, j=0}^{i+j=n}c_{ij} * x^{i} * y^{j}$$
 
   Invertability: This transform is not automatically invertible.
 
 examples:
   -
-    - :math:`P = 1.2 + 0.3 * x + 56.1 * x^{2}`
+    - $P = 1.2 + 0.3 * x + 56.1 * x^{2}$
     - |
         !transform/polynomial
           coefficients: !core/ndarray
                           [1.2, 0.3, 56.1]
   -
-    - :math:`P = 1.2 + 0.3 * x + 3 * x * y + 2.1 * y^{2}`
+    - $P = 1.2 + 0.3 * x + 3 * x * y + 2.1 * y^{2}$
     - |
         !transform/polynomial
           coefficients: !core/ndarray
@@ -41,4 +41,3 @@ properties:
       - $ref: ../core/ndarray
       - type: array
 required: [coefficients]
-

--- a/schemas/stsci.edu/asdf/0.1.0/transform/remap_axes.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/remap_axes.yaml
@@ -21,8 +21,8 @@ description: |
 
   If only a list is provided, the number of input axes is
   automatically determined from the maximum index in the list.  If an
-  object with ``mapping`` and ``n_inputs`` properties is provided, the
-  number of input axes is explicitly set by the ``n_inputs`` value.
+  object with `mapping` and `n_inputs` properties is provided, the
+  number of input axes is explicitly set by the `n_inputs` value.
 
   Invertibility: TBD
 examples:

--- a/schemas/stsci.edu/asdf/0.1.0/transform/tangent.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/transform/tangent.yaml
@@ -7,7 +7,7 @@ title: |
   A tangent (gnomonic) projection.
 
 description: |
-  Corresponds to the ``TAN`` projection in the FITS WCS standard.
+  Corresponds to the `TAN` projection in the FITS WCS standard.
 
   Invertability: All ASDF tools are required to be able to compute the
   analytic inverse of this transform.

--- a/schemas/stsci.edu/asdf/0.1.0/unit/unit.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/unit/unit.yaml
@@ -4,8 +4,8 @@ $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/0.1.0/unit/unit"
 title: Physical unit.
 description: >
-  This represents a physical unit, in  `VOUnit syntax, Version 1.0
-  <http://www.ivoa.net/documents/VOUnits/index.html>`__.
+  This represents a physical unit, in [VOUnit syntax, Version
+  1.0](http://www.ivoa.net/documents/VOUnits/index.html).
 
   Where units are not explicitly tagged, they are assumed to be
   in VOUnit syntax.

--- a/schemas/stsci.edu/asdf/0.1.0/wcs/axis.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/wcs/axis.yaml
@@ -17,22 +17,22 @@ properties:
       The type of frame for this axis.  It must have one of the
       following values:
 
-      - ``celestial``: Celestial coordinates.  A ``celestial_type``
+      - `celestial`: Celestial coordinates.  A `celestial_type`
         property must also be given.
 
-      - ``time``: Time coordinate.  A ``time_scale`` property must
-        also be given.
+      - `time`: Time coordinate.  A `time_scale` property must also be
+        given.
 
-      - ``spectral``: Spectral coordinate.
+      - `spectral`: Spectral coordinate.
 
-      - ``cartesian``: Cartesian coordinate.
+      - `cartesian`: Cartesian coordinate.
 
-      - ``detector``: Native detector coordinate.
+      - `detector`: Native detector coordinate.
 
-      - ``focal_plane``: A coordinate in the focal plane.  Naturally,
+      - `focal_plane`: A coordinate in the focal plane.  Naturally,
         these coordinates will be instrument specific.
 
-      - ``custom``: A custom axis frame that is not one of the above.
+      - `custom`: A custom axis frame that is not one of the above.
         Additional information about the frame may be stored in
         additional properties as a non-standard extension.
 
@@ -47,17 +47,17 @@ properties:
 
   celestial_type:
     description: |
-      If ``type`` is "celestial", this property must be given.
+      If `type` is "celestial", this property must be given.
 
-      - FK4: Celestial coordinates in the FK4 system.  ``equinox`` and
-        ``observation_time`` may also be given.  ``name`` should be
-        ``ra`` or ``dec``.
-      - FK5: Celestial coordinates in the FK5 system.  ``equinox`` may
-        also be given.  ``name`` should be ``ra`` or ``dec``.
-      - ICRS: Celestial coordinates in the ICRS system.  ``name``
-        should be ``ra`` or ``dec``.
-      - galactic: Galactic coordinates.  ``name`` should be ``lon`` or
-        ``lat``.
+      - FK4: Celestial coordinates in the FK4 system.  `equinox` and
+        `observation_time` may also be given.  `name` should be `ra`
+        or `dec`.
+      - FK5: Celestial coordinates in the FK5 system.  `equinox` may
+        also be given.  `name` should be `ra` or `dec`.
+      - ICRS: Celestial coordinates in the ICRS system.  `name` should
+        be `ra` or `dec`.
+      - galactic: Galactic coordinates.  `name` should be `lon` or
+        `lat`.
 
     enum:
       - FK4
@@ -75,7 +75,7 @@ properties:
   observation_time:
     description: |
       The observation time of the celestial frame, if different from
-      ``equinox``.
+      `equinox`.
     type: string # ../time/time
 
   time_scale:
@@ -104,7 +104,7 @@ properties:
 
   name:
     description: |
-      The name of the axis.  If the ``type`` is multidimensional, such
+      The name of the axis.  If the `type` is multidimensional, such
       as "celestial", this name has meaning, and must correspond to
       it.  For example, for a celestial ICRS frame, it must be either
       "ra" or "dec".  Otherwise, it may be an arbitrary name for the

--- a/schemas/stsci.edu/asdf/0.1.0/wcs/wcs.yaml
+++ b/schemas/stsci.edu/asdf/0.1.0/wcs/wcs.yaml
@@ -19,8 +19,8 @@ properties:
 
       The inverse transformation is determined automatically by
       reversing this list, and inverting each of the individual
-      transforms according to the rules described in :ref:`inverse
-      <http://stsci.edu/schemas/asdf/0.1.0/transform/transform/anyOf/0/properties/inverse>`.
+      transforms according to the rules described in
+      [inverse](ref:http://stsci.edu/schemas/asdf/0.1.0/transform/transform/anyOf/0/properties/inverse).
 
     $ref: steps
 

--- a/source/extending.rst
+++ b/source/extending.rst
@@ -38,8 +38,8 @@ YAML Schema adds three new keywords to JSON Schema.
 ``tag``, which may be attached to any data type, declares that the
 element must have the given YAML tag.
 
-For example, the root :ref:`ASDF schema
-<http://stsci.edu/schemas/asdf/0.1.0/core/asdf>` declares that
+For example, the root :ref:`asdf
+<http://stsci.edu/schemas/asdf/0.1.0/core/asdf>` schema declares that
 the ``data`` property must be an :ref:`ndarray
 <http://stsci.edu/schemas/asdf/0.1.0/core/ndarray>`.  It does
 this not by using the ``tag`` keyword directly, but by referencing the

--- a/source/extending.rst
+++ b/source/extending.rst
@@ -159,7 +159,7 @@ Descriptive information
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 Each schema has some descriptive fields: ``title``, ``description``
-and ``examples``.
+and ``examples``.  These fields may contain core markdown syntax.
 
 - ``title``: A one-line summary of what the schema is for.
 


### PR DESCRIPTION
It seemed silly to support restructuredtext in the schema descriptions, since that's a fairly Python-specific tool.  This changes things so it use the more universally-known markdown syntax.

Adds a dependency (just to build the standard docs) on `mistune` to parse the markdown.