### PR TITLE
flow_style -> flowStyle for consistency with camelCase of other keywords

### DIFF
--- a/schemas/stsci.edu/yaml-schema/draft-01.yaml
+++ b/schemas/stsci.edu/yaml-schema/draft-01.yaml
@@ -31,7 +31,7 @@ allOf:
         items:
           type: string
 
-      flow_style:
+      flowStyle:
         description: |
           Specifies the default serialization style to use for an
           array or object.  YAML supports multiple styles for


### PR DESCRIPTION
If any associated changes need to be made in pyasdf I'll do that too.

<s>Relatedly, I was reading the descriptions of this, and the `style` keyword, and thought of adding a note that implementations *may* check this on reading too.  It would be up to implementations decide how to alert about objects that are not given in the specified style, though the recommended default is to ignore it.</s>

<s>I don't know, what do you think?  I feel like in general this should be ignored on reading, but I think there could also be value in using this for checking a file to *strict* adherence to convention, and that implementations should at least know that they have that option.  I believe this is possible to do within pyyaml but I'm not certain.</s>

On second thought, scratch all that.  That has the same problem as trying to preserve comments, I guess.  This would have to hook schema validation deep into the YAML parser in a way that might be doable but probably isn't practical in the current model.