### PR TITLE
unknown document: http://json-schema.org/draft-04/schema

### DIFF
--- a/convert_schemas.py
+++ b/convert_schemas.py
@@ -163,7 +163,12 @@ def format_type(schema, root):
             return ':ref:`{0} <{1}/{2}>`'.format(ref[2:], root, ref[2:])
         else:
             basename = os.path.basename(schema['$ref'])
-            return ':doc:`{0} <{1}>`'.format(basename, schema['$ref'])
+            # Link references to external schemas; currently used only to
+            # linke to JSON Schema itself
+            if schema['$ref'].startswith('http:'):
+                return '`{0} <{1}>`__'.format(basename, schema['$ref'])
+            else:
+                return ':doc:`{0} <{1}>`'.format(basename, schema['$ref'])
 
     else:
         type = schema.get('type')


### PR DESCRIPTION
When building the docs I get the following two warnings:

```
asdf-standard/source/schemas/stsci.edu/yaml-schema/draft-01.rst:8: WARNING: unknown document: http://json-schema.org/draft-04/schema
asdf-standard/source/schemas/stsci.edu/yaml-schema/draft-01.rst:27: WARNING: unknown document: http://json-schema.org/draft-04/schema
```

this seems to be because the format output by the convert_scripts.py script allows a schema to link back to the schema it inherits from, I think.  But in the case of the YAML Schema metaschema, it links to the JSON Schema metaschema, which isn't included in the asdf-standard docs.  Maybe we should just add a copy of it too?  That should probably resolve this.