### PR TITLE
Show raw YAML on rendered schema pages, in addition to raw download link

### DIFF
--- a/convert_schemas.py
+++ b/convert_schemas.py
@@ -370,8 +370,12 @@ def convert_schema_to_rst(src, dst):
         name += ': ' + schema['title'].strip()
     recurse(o, name, schema, [id], 0)
 
-    o.write(".. only:: html\n\n   :download:`Original schema in YAML <{0}>`\n".format(
+    write_header(o, 'Original schema in YAML', 1)
+    o.write(".. only:: html\n\n   :download:`[Download raw] <{0}>`\n".format(
         os.path.basename(src)))
+    o.write(".. literalinclude:: {0}\n".format(os.path.basename(dst)))
+    o.write("    :language: yaml\n")
+    o.write("    :linenos:\n\n")
 
     write_if_different(dst, yaml_content)
     write_if_different(dst[:-5] + ".rst", o.getvalue().encode('utf-8'))


### PR DESCRIPTION
Instead of providing just a download link on schema pages, show the original YAML with syntax highlighting *and* provide a raw download links. 

For example:
![asdf-schema-page](https://cloud.githubusercontent.com/assets/676149/9388372/dfffce46-4732-11e5-9cef-489ec190987a.png)
