### PR TITLE
fix a bug in tabular model

### DIFF
--- a/schemas/stsci.edu/asdf/transform/tabular-1.0.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/tabular-1.0.0.yaml
@@ -21,10 +21,12 @@ properties:
       - $ref: ../core/ndarray-1.0.0
       - type: array
   points:
-    $ref: ../core/ndarray-1.0.0
+    type: array
+    items:
+      $ref: ../core/ndarray-1.0.0
     description: |
       Grid values - each row in the array corresponds to a dimension
-      in the lookup table. The grid does not have o be regular.
+      in the lookup table. The grid does not have to be regular.
   method:
     description: |
       Method of interpolation. Supported are "linear" and


### PR DESCRIPTION
When the table has different dimensions in x and y `points` is a tuple of arrays with different sizes. Turning this into array creates an array of `dtype=object` which cannot be saved.
This is fixed by saving the `points` tuple as a list of arrays.