### PR TITLE
Update wcs schemas to reflect astropy changes

### DIFF
--- a/schemas/stsci.edu/asdf/wcs/frame-1.0.0.yaml
+++ b/schemas/stsci.edu/asdf/wcs/frame-1.0.0.yaml
@@ -168,15 +168,13 @@ properties:
           when `reference_frame` is `GCRS` or `precessed_geocentric`.
         type: array
         items:
-          - type: array
-            items:
-              type: number
-            minItems: 3
-            maxItems: 3
-          - $ref: ../unit/unit-1.0.0
-            default: m
+          $ref: quantity-1.0.0
+        minItems: 3
+        maxItems: 3
         default:
-          - [0, 0, 0]
+          - { value: [0], unit: m }
+          - { value: [0], unit: m }
+          - { value: [0], unit: m }
 
       obsgeovel:
         description: |
@@ -186,15 +184,13 @@ properties:
           when `reference_frame` is `GCRS` or `precessed_geocentric`.
         type: array
         items:
-          - type: array
-            items:
-              type: number
-            minItems: 3
-            maxItems: 3
-          - $ref: ../unit/unit-1.0.0
-            default: m/s
+          $ref: quantity-1.0.0
+        minItems: 3
+        maxItems: 3
         default:
-          - [0, 0, 0]
+          - { value: [0], unit: m/s }
+          - { value: [0], unit: m/s }
+          - { value: [0], unit: m/s }
 
     required: [type]
 

--- a/schemas/stsci.edu/asdf/wcs/quantity-1.0.0.yaml
+++ b/schemas/stsci.edu/asdf/wcs/quantity-1.0.0.yaml
@@ -1,0 +1,27 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/wcs/quantity-1.0.0"
+
+title: >
+  Represents a Quantity object from astropy
+
+anyOf:
+  - tag: "tag:stsci.edu:asdf/wcs/quantity-1.0.0"
+  - {}
+
+type: object
+properties:
+  value:
+    description: |
+      A vector of one or more values
+    type: array
+    items:
+      type: number
+    minItems: 1
+  unit:
+    description: |
+      The unit corresponding to the values
+    $ref: ../unit/unit-1.0.0
+required: [value, unit]
+...


### PR DESCRIPTION
Astropy changed its representation of the ``obsgeoloc`` and ``obsgeovel``properties from ``Quantity`` objects to ``CartesianRepresentation`` objects.

This commit adds a new ``Quantity`` schema since each dimension of a ``CartesianRepresentation`` can be represented as a ``Quantity`` with a unique value and unit. It updates the ``wcs`` frame schema to represent a ``CartesianRepresentation`` as an array of ``Quantity`` objects.