### PR TITLE
Composite frame schema no longer allows singleton frames

### DIFF
--- a/schemas/stsci.edu/asdf/wcs/composite_frame-1.1.0.yaml
+++ b/schemas/stsci.edu/asdf/wcs/composite_frame-1.1.0.yaml
@@ -18,5 +18,3 @@ allOf:
         description:
           List of frames in the composite frame.
         type: array
-
-  - $ref: frame-1.1.0


### PR DESCRIPTION
This was never supported in tag code and does not appear to be necessary for the schema.