### PR TITLE
add tabular to versionmap

### DIFF
--- a/schemas/stsci.edu/asdf/version_map-1.0.0.yaml
+++ b/schemas/stsci.edu/asdf/version_map-1.0.0.yaml
@@ -62,6 +62,7 @@ tags:
   tag:stsci.edu:asdf/transform/slant_zenithal_perspective: 1.0.0
   tag:stsci.edu:asdf/transform/stereographic: 1.0.0
   tag:stsci.edu:asdf/transform/subtract: 1.0.0
+  tag:stsci.edu:asdf/transform/tabular: 1.0.0
   tag:stsci.edu:asdf/transform/tangential_spherical_cube: 1.0.0
   tag:stsci.edu:asdf/transform/transform: 1.0.0
   tag:stsci.edu:asdf/transform/zenithal: 1.0.0

--- a/schemas/stsci.edu/asdf/version_map-1.1.0.yaml
+++ b/schemas/stsci.edu/asdf/version_map-1.1.0.yaml
@@ -61,6 +61,7 @@ tags:
   tag:stsci.edu:asdf/transform/slant_zenithal_perspective: 1.1.0
   tag:stsci.edu:asdf/transform/stereographic: 1.1.0
   tag:stsci.edu:asdf/transform/subtract: 1.1.0
+  tag:stsci.edu:asdf/transform/tabular: 1.1.0
   tag:stsci.edu:asdf/transform/tangential_spherical_cube: 1.1.0
   tag:stsci.edu:asdf/transform/transform: 1.1.0
   tag:stsci.edu:asdf/transform/zenithal: 1.1.0


### PR DESCRIPTION
Schema for tabular model is missing from the version 1.1.0 map.