### PR TITLE
Allow inline ndarrays to contain arbitrary objects

### DIFF
--- a/schemas/stsci.edu/asdf/core/ndarray-1.0.0.yaml
+++ b/schemas/stsci.edu/asdf/core/ndarray-1.0.0.yaml
@@ -267,6 +267,7 @@ definitions:
         - $ref: "complex-1.0.0"
         - $ref: "#/definitions/inline-data"
         - type: boolean
+        - {}
 
 anyOf:
   - $ref: "#/definitions/inline-data"


### PR DESCRIPTION
This is a minor change to the `ndarray` schema that allows inline ndarrays to store arbitary objects. For example, this makes the following code possible (in conjunction with some WIP tag updates), where previously it was not:

```python
import asdf
import numpy as np

data = np.empty((10, 10), dtype=object)
for i, _ in enumerate(data.flat):
    data.flat[i] = SomeObject(i, foo, 42)

af = asdf.AsdfFile({'data': data})
af.write_to('data.asdf')
```

@nden, @perrygreenfield this is a very minor change: I wonder if we can sneak this in to the `ndarray-1.0.0` schema so that we don't cause a rather significant cascade of schema updates. If not, I'll close this PR and open a new one.

Thanks @Cadair for bringing this to our attention and for your work towards a solution.