### PR TITLE
Fix erroneous use of "requiredProperties" in schemas

### DIFF
--- a/schemas/stsci.edu/asdf/core/column-1.0.0.yaml
+++ b/schemas/stsci.edu/asdf/core/column-1.0.0.yaml
@@ -45,5 +45,5 @@ properties:
     type: object
     default: {}
 
-requiredProperties: [name, data]
+required: [name, data]
 additionalProperties: false

--- a/schemas/stsci.edu/asdf/core/externalarray-1.0.0.yaml
+++ b/schemas/stsci.edu/asdf/core/externalarray-1.0.0.yaml
@@ -20,7 +20,7 @@ examples:
 
 type: object
 properties:
-  source:
+  fileuri:
     type: string
   target:
     anyOf:
@@ -35,6 +35,6 @@ properties:
       - type: integer
         minimum: 0
 
-requiredProperties: [source, target, datatype, shape]
+required: [fileuri, target, datatype, shape]
 additionalProperties: true
 ...

--- a/schemas/stsci.edu/asdf/core/history_entry-1.0.0.yaml
+++ b/schemas/stsci.edu/asdf/core/history_entry-1.0.0.yaml
@@ -29,5 +29,5 @@ properties:
         items:
           $ref: "software-1.0.0"
 
-requiredProperties: [description]
+required: [description]
 additionalProperties: true

--- a/schemas/stsci.edu/asdf/core/table-1.0.0.yaml
+++ b/schemas/stsci.edu/asdf/core/table-1.0.0.yaml
@@ -105,4 +105,4 @@ properties:
     default: {}
 
 additionalProperties: false
-requiredProperties: [data]
+required: [columns]


### PR DESCRIPTION
Several of the schemas were using `requiredProperties` instead of `required` to indicate schema properties that are required. This has now been fixed.

The use of the invalid property `requiredProperties` meant that these schemas were not being properly validated, which hid a few relatively minor bugs. These bugs have now been fixed.

@nden this should have no impact on the JWST pipeline, so I think this can be merged as soon as tests pass.