### PR TITLE
Update top-level ASDF core schema to v1.1.0

### DIFF
--- a/schemas/stsci.edu/asdf/core/asdf-1.1.0.yaml
+++ b/schemas/stsci.edu/asdf/core/asdf-1.1.0.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/core/asdf-1.1.0"
+title: |
+  Top-level schema for every ASDF file.
+
+description: |
+  This schema contains the top-level attributes for every ASDF file.
+
+tag: "tag:stsci.edu:asdf/core/asdf-1.1.0"
+type: object
+properties:
+  asdf_library:
+    description: |
+      Describes the ASDF library that produced the file.
+    $ref: "software-1.0.0"
+
+  history:
+    description: |
+      A log of transformations that have happened to the file.  May
+      include such things as data collection, data calibration
+      pipelines, data analysis etc.
+    type: array
+    items:
+      $ref: "history_entry-1.0.0"
+
+additionalProperties: true
+...

--- a/schemas/stsci.edu/asdf/version_map-1.2.0.yaml
+++ b/schemas/stsci.edu/asdf/version_map-1.2.0.yaml
@@ -4,7 +4,7 @@ FILE_FORMAT: 1.0.0
 YAML_VERSION: "1.1"
 tags:
   tag:stsci.edu:asdf/asdf-schema: 1.0.0
-  tag:stsci.edu:asdf/core/asdf: 1.0.0
+  tag:stsci.edu:asdf/core/asdf: 1.1.0
   tag:stsci.edu:asdf/core/column: 1.0.0
   tag:stsci.edu:asdf/core/complex: 1.0.0
   tag:stsci.edu:asdf/core/constant: 1.0.0


### PR DESCRIPTION
This PR removes restrictions on the top-level `data`, `wcs`, and `fits` attributes.