### PR TITLE
Update core history section to include extension metadata

### DIFF
--- a/schemas/stsci.edu/asdf/core/asdf-1.1.0.yaml
+++ b/schemas/stsci.edu/asdf/core/asdf-1.1.0.yaml
@@ -21,11 +21,30 @@ properties:
       A log of transformations that have happened to the file.  May
       include such things as data collection, data calibration
       pipelines, data analysis etc.
-    type: array
-    items:
-      anyOf:
-        - $ref: "history_entry-1.0.0"
-        - $ref: "extension_metadata-1.0.0"
+    anyOf:
+      # This is to support backwards compatibility with older history formats
+      - type: array
+        items:
+          - $ref: "history_entry-1.0.0"
+      # This is the new, richer history implementation that includes
+      # extension metadata.
+      - $ref: "#/definitions/history-1.1.0"
 
 additionalProperties: true
+
+
+# This contains the definition of the new history format, which includes
+# metadata about the extensions used to create the file.
+definitions:
+  history-1.1.0:
+    type: object
+    properties:
+      extensions:
+        type: array
+        items:
+          - $ref: "extension_metadata-1.0.0"
+      entries:
+        type: array
+        items:
+          - $ref: "history_entry-1.0.0"
 ...

--- a/schemas/stsci.edu/asdf/core/asdf-1.1.0.yaml
+++ b/schemas/stsci.edu/asdf/core/asdf-1.1.0.yaml
@@ -23,7 +23,9 @@ properties:
       pipelines, data analysis etc.
     type: array
     items:
-      $ref: "history_entry-1.0.0"
+      anyOf:
+        - $ref: "history_entry-1.0.0"
+        - $ref: "extension_metadata-1.0.0"
 
 additionalProperties: true
 ...

--- a/schemas/stsci.edu/asdf/core/extension_metadata-1.0.0.yaml
+++ b/schemas/stsci.edu/asdf/core/extension_metadata-1.0.0.yaml
@@ -1,0 +1,21 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/core/extension_metadata-1.0.0"
+title: |
+  Metadata about specific ASDF extensions that were used to create this file.
+
+tag: "tag:stsci.edu:asdf/core/extension_metadata-1.0.0"
+type: object
+properties:
+  extension_class:
+    description: |
+      The fully-specified name of the extension class.
+    type: string
+
+  package:
+    description: |
+      The name and version of the package that contains the extension.
+    $ref: "software-1.0.0"
+
+required: [extension_class]

--- a/schemas/stsci.edu/asdf/core/software-1.0.0.yaml
+++ b/schemas/stsci.edu/asdf/core/software-1.0.0.yaml
@@ -31,5 +31,5 @@ properties:
       Specification)[http://semver.org/spec/v2.0.0.html].
     type: string
 
-required: [name, author, homepage, version]
+required: [name, version]
 additionalProperties: true


### PR DESCRIPTION
This update allows ASDF implementations to store metadata about the extensions that were used to create particular files. It allows for backwards compatibility with earlier versions of the history section.