### PR TITLE
Update core schema: metadata fields are always written at the top

### DIFF
--- a/schemas/stsci.edu/asdf/core/asdf-1.1.0.yaml
+++ b/schemas/stsci.edu/asdf/core/asdf-1.1.0.yaml
@@ -31,6 +31,8 @@ properties:
       - $ref: "#/definitions/history-1.1.0"
 
 additionalProperties: true
+# Make sure that these two metadata fields are always at the top of the file
+propertyOrder: [asdf_library, history]
 
 
 # This contains the definition of the new history format, which includes


### PR DESCRIPTION
This is a minor update to the core schema to ensure that the metadata fields `asdf_library` and `history` are always written to the file at the top of the tree.