### PR TITLE
Run schema tests as part of CI build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
 *.pyc
+*.pytest_cache
 
 source/schemas/stsci.edu

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 env:
   global:
     - secure: "W3PaYhPnJFCaG6TW5Xc0wtggdEqcreTQcHThmIo5Eqs/jUL2toiUiv3ZWlhzR3tkphLvt2KeaQe83BR6RTifYjSmnmAePj0Gw5res1AXzN95OsKEk3nMiTZbVP+PuTTbQZJga8B31nRUBiAMQ6FsNlpGq7E8sp9N65lnR3mGHAE="
+    - PIP_DOC_DEPENDENCIES="six sphinx sphinx_bootstrap_theme jsonschema pyyaml mistune"
+    - ASDF_MASTER="git+git://github.com/spacetelescope/asdf"
 
 sudo: false
 
@@ -15,11 +17,15 @@ branches:
   only:
     - master
 
-before_install:
-  - pip install six sphinx sphinx_bootstrap_theme jsonschema pyyaml mistune
+jobs:
+  include:
+    # Build documentation
+    - before_install:
+        - pip install $PIP_DOC_DEPENDENCIES
+      install: python setup.py
+      script: make html
 
-install:
-  - python setup.py
-
-script:
-  - make html
+    # Run schema validation and example tests using pytest
+    - before_install:
+        - pip install $ASDF_MASTER pytest
+      script: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,8 @@ jobs:
     # Run schema validation and example tests using pytest
     - before_install:
         - pip install $ASDF_MASTER pytest
+        # We need to install these packages because they contain the canonical
+        # implementations for some of the schemas we need to test
+        - pip install astropy gwcs
       install: echo Nothing to install
       script: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ addons:
 
 language: python
 
+python:
+  - 3.6
+
 branches:
   only:
     - master
@@ -28,4 +31,5 @@ jobs:
     # Run schema validation and example tests using pytest
     - before_install:
         - pip install $ASDF_MASTER pytest
+      install: echo Nothing to install
       script: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,16 +20,16 @@ branches:
   only:
     - master
 
-jobs:
+matrix:
   include:
-    # Build documentation
-    - before_install:
+    - name: "Documentation build"
+      before_install:
         - pip install $PIP_DOC_DEPENDENCIES
       install: python setup.py
       script: make html
 
-    # Run schema validation and example tests using pytest
-    - before_install:
+    - name: "Schema validation tests"
+      before_install:
         - pip install $ASDF_MASTER pytest
         # We need to install these packages because they contain the canonical
         # implementations for some of the schemas we need to test

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,3 @@
+pytest_plugins = [
+    'asdf.tests.schema_tester'
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[tool:pytest]
+asdf_schema_root = schemas
+asdf_schema_skip_names = asdf-schema-1.0.0 draft-01


### PR DESCRIPTION
Currently the schemas and their examples are only tested in CI runs in [asdf](https://github.com/spacetelescope/asdf). However, it seems like a good idea to test changes to schemas independently here. We use the development branch of the Python implementation to run the tests.