### PR TITLE
Remove domain field from transform schema

### DIFF
--- a/schemas/stsci.edu/asdf/transform/add-1.2.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/add-1.2.0.yaml
@@ -1,0 +1,34 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/add-1.2.0"
+tag: "tag:stsci.edu:asdf/transform/add-1.2.0"
+title: >
+  Perform a list of subtransforms in parallel and then
+  add their results together.
+
+description: |
+  Each of the subtransforms must have the same number of inputs and
+  outputs.
+
+examples:
+  -
+    - A list of transforms, performed in parallel and added together
+    - |
+      !transform/add-1.2.0
+        forward:
+          - !transform/generic-1.1.0
+            n_inputs: 1
+            n_outputs: 2
+          - !transform/generic-1.1.0
+            n_inputs: 1
+            n_outputs: 2
+
+allOf:
+  - $ref: "transform-1.2.0"
+  - properties:
+      forward:
+        type: array
+        items:
+          $ref: "transform-1.2.0"
+    required: [forward]

--- a/schemas/stsci.edu/asdf/transform/affine-1.3.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/affine-1.3.0.yaml
@@ -1,0 +1,45 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/affine-1.3.0"
+tag: "tag:stsci.edu:asdf/transform/affine-1.3.0"
+title: >
+  An affine transform.
+description: |
+  Invertibility: All ASDF tools are required to be able to compute the
+  analytic inverse of this transform.
+
+
+allOf:
+  - $ref: "transform-1.2.0"
+  - type: object
+    properties:
+      matrix:
+        description: |
+          An array of size (*n* x *n*), where *n* is the number of axes,
+          representing the linear transformation in an affine transform.
+        anyOf:
+          - $ref: "../core/ndarray-1.0.0"
+          - $ref: "../unit/quantity-1.1.0"
+          - type: array
+            items:
+              type: array
+              items:
+                type: number
+              minItems: 2
+              maxItems: 2
+            minItems: 2
+            maxItems: 2
+      translation:
+        description: |
+          An array of size (*n*,), where  *n* is the number of axes,
+          representing the translation in an affine transform.
+        anyOf:
+          - $ref: "../core/ndarray-1.0.0"
+          - $ref: "../unit/quantity-1.1.0"
+          - type: array
+            items:
+              type: number
+            minItems: 2
+            maxItems: 2
+    required: [matrix]

--- a/schemas/stsci.edu/asdf/transform/compose-1.2.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/compose-1.2.0.yaml
@@ -1,0 +1,42 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/compose-1.2.0"
+tag: "tag:stsci.edu:asdf/transform/compose-1.2.0"
+title: >
+  Perform a list of subtransforms in series.
+
+description: |
+  The output of each subtransform is fed into the input of the next
+  subtransform.
+
+  The number of output dimensions of each subtransform must be equal
+  to the number of input dimensions of the next subtransform in list.
+  To reorder or add/drop axes, insert `remap_axes` transforms in the
+  subtransform list.
+
+  Invertibility: All ASDF tools are required to be able to compute the
+  analytic inverse of this transform, by reversing the list of
+  transforms and applying the inverse of each.
+
+examples:
+  -
+    - A series of transforms
+    - |
+      !transform/compose-1.2.0
+        forward:
+          - !transform/generic-1.1.0
+            n_inputs: 1
+            n_outputs: 2
+          - !transform/generic-1.1.0
+            n_inputs: 2
+            n_outputs: 1
+
+allOf:
+  - $ref: "transform-1.2.0"
+  - properties:
+      forward:
+        type: array
+        items:
+          $ref: "transform-1.2.0"
+    required: [forward]

--- a/schemas/stsci.edu/asdf/transform/concatenate-1.2.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/concatenate-1.2.0.yaml
@@ -1,0 +1,68 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/concatenate-1.2.0"
+tag: "tag:stsci.edu:asdf/transform/concatenate-1.2.0"
+title: >
+  Send axes to different subtransforms.
+
+description: |
+  Transforms a set of separable inputs by splitting the axes apart,
+  sending them through the given subtransforms in parallel, and
+  finally concatenating the subtransform output axes back together.
+
+  The input axes are assigned to each subtransform in order.  If the
+  number of input axes is unequal to the sum of the number of input
+  axes of all of the subtransforms, that is considered an error case.
+
+  The output axes from each subtransform are appended together to make
+  up the resulting output axes.
+
+  For example, given 5 input axes, and 3 subtransforms with the
+  following orders:
+
+  1. transform A: 2 in -> 2 out
+  1. transform B: 1 in -> 2 out
+  1. transform C: 2 in -> 1 out
+
+  The transform is performed as follows:
+
+  ```
+    :    i0    i1       i2       i3    i4
+    :    |     |        |        |     |
+    :  +---------+ +---------+ +----------+
+    :  |    A    | |    B    | |    C     |
+    :  +---------+ +---------+ +----------+
+    :    |     |     |     |        |
+    :    o0    o1    o2    o3       o4
+  ```
+
+  If reordering of the input or output axes is required, use in series
+  with the `remap_axes` transform.
+
+  Invertibility: All ASDF tools are required to be able to compute the
+  analytic inverse of this transform.
+examples:
+  -
+    - The example in the description
+    - |
+      !transform/concatenate-1.2.0
+        forward:
+          - !transform/generic-1.1.0
+            n_inputs: 2
+            n_outputs: 2
+          - !transform/generic-1.1.0
+            n_inputs: 1
+            n_outputs: 2
+          - !transform/generic-1.1.0
+            n_inputs: 2
+            n_outputs: 1
+
+allOf:
+  - $ref: "transform-1.2.0"
+  - properties:
+      forward:
+        type: array
+        items:
+          $ref: "transform-1.2.0"
+    required: [forward]

--- a/schemas/stsci.edu/asdf/transform/conic-1.3.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/conic-1.3.0.yaml
@@ -1,0 +1,50 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/conic-1.3.0"
+title: |
+  Base class of all conic projections.
+
+description: |
+  In conic projections, the sphere is thought to be projected onto the
+  surface of a cone which is then opened out.
+
+  In a general sense, the pixel-to-sky transformation is defined as:
+
+  $$\phi &= \arg\left(\frac{Y_0 - y}{R_\theta}, \frac{x}{R_\theta}\right) / C \\
+    R_\theta &= \mathrm{sign} \theta_a \sqrt{x^2 + (Y_0 - y)^2}$$
+
+  and the inverse (sky-to-pixel) is defined as:
+
+  $$x &= R_\theta \sin (C \phi) \\
+    y &= R_\theta \cos (C \phi) + Y_0$$
+
+  where $C$ is the "constant of the cone":
+
+  $$C = \frac{180^\circ \cos \theta}{\pi R_\theta}$$
+
+allOf:
+  - $ref: "transform-1.2.0"
+  - type: object
+    properties:
+      direction:
+        enum: [pix2sky, sky2pix]
+        default: pix2sky
+
+      sigma:
+        anyOf:
+          - $ref: "../unit/quantity-1.1.0"
+          - type: number
+        description: |
+          $(\theta_1 + \theta_2) / 2$ where $\theta_1$ and $\theta_2$
+          are the latitudes of the standard parallels, in degrees.
+        default: 0
+
+      delta:
+        anyOf:
+          - $ref: "../unit/quantity-1.1.0"
+          - type: number
+        description: |
+          $(\theta_1 - \theta_2) / 2$ where $\theta_1$ and $\theta_2$
+          are the latitudes of the standard parallels, in degrees.
+        default: 0

--- a/schemas/stsci.edu/asdf/transform/constant-1.3.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/constant-1.3.0.yaml
@@ -1,0 +1,20 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/constant-1.3.0"
+tag: "tag:stsci.edu:asdf/transform/constant-1.3.0"
+title: >
+  A transform that takes no inputs and always outputs a constant
+  value.
+description: |
+  Invertibility: All ASDF tools are required to be able to compute the
+  analytic inverse of this transform, which always outputs zero values.
+allOf:
+  - $ref: "transform-1.2.0"
+  - type: object
+    properties:
+      value:
+        anyOf:
+          - $ref: "../unit/quantity-1.1.0"
+          - type: number
+    required: [value]

--- a/schemas/stsci.edu/asdf/transform/cylindrical-1.2.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/cylindrical-1.2.0.yaml
@@ -1,0 +1,17 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/cylindrical-1.2.0"
+title: |
+  Base class of all cylindrical projections.
+
+description: |
+  The surface of cylindrical projections is a cylinder.
+
+allOf:
+  - $ref: "transform-1.2.0"
+  - type: object
+    properties:
+      direction:
+        enum: [pix2sky, sky2pix]
+        default: pix2sky

--- a/schemas/stsci.edu/asdf/transform/divide-1.2.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/divide-1.2.0.yaml
@@ -1,0 +1,36 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/divide-1.2.0"
+tag: "tag:stsci.edu:asdf/transform/divide-1.2.0"
+title: >
+  Perform a list of subtransforms in parallel and then
+  divide their results.
+
+description: |
+  Each of the subtransforms must have the same number of inputs and
+  outputs.
+
+  Invertibility: This transform is not automatically invertible.
+examples:
+  -
+    - A list of transforms, performed in parallel, and then combined
+      through division.
+    - |
+      !transform/divide-1.2.0
+        forward:
+          - !transform/generic-1.1.0
+            n_inputs: 1
+            n_outputs: 2
+          - !transform/generic-1.1.0
+            n_inputs: 1
+            n_outputs: 2
+
+allOf:
+  - $ref: "transform-1.2.0"
+  - properties:
+      forward:
+        type: array
+        items:
+          $ref: "transform-1.2.0"
+    required: [forward]

--- a/schemas/stsci.edu/asdf/transform/generic-1.2.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/generic-1.2.0.yaml
@@ -1,0 +1,21 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/generic-1.2.0"
+tag: "tag:stsci.edu:asdf/transform/generic-1.2.0"
+title: >
+  A generic transform.
+description: >
+  This is used **entirely** for bootstrapping purposes so one can
+  create composite models including transforms that haven't yet been
+  written.  **IT WILL NOT BE IN THE FINAL VERSION OF THE SPEC**.
+
+allOf:
+  - $ref: "transform-1.2.0"
+  - type: object
+    properties:
+      n_inputs:
+        type: integer
+      n_outputs:
+        type: integer
+    required: [n_inputs, n_outputs]

--- a/schemas/stsci.edu/asdf/transform/healpix-1.2.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/healpix-1.2.0.yaml
@@ -1,0 +1,33 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/healpix-1.2.0"
+tag: "tag:stsci.edu:asdf/transform/healpix-1.2.0"
+title: |
+  HEALPix projection.
+
+description: |
+  Corresponds to the `XPH` projection in the FITS WCS standard.
+
+  Invertibility: All ASDF tools are required to provide the inverse of
+  this transform.
+
+allOf:
+  - $ref: "transform-1.2.0"
+  - type: object
+    properties:
+      direction:
+        enum: [pix2sky, sky2pix]
+        default: pix2sky
+
+      H:
+        type: number
+        description: |
+          The number of facets in the longitude direction.
+        default: 4.0
+
+      X:
+        type: number
+        description: |
+          The number of facets in the latitude direction.
+        default: 3.0

--- a/schemas/stsci.edu/asdf/transform/healpix_polar-1.2.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/healpix_polar-1.2.0.yaml
@@ -1,0 +1,21 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/healpix_polar-1.2.0"
+tag: "tag:stsci.edu:asdf/transform/healpix_polar-1.2.0"
+title: |
+  HEALPix polar, aka "butterfly", projection.
+
+description: |
+  Corresponds to the `XPH` projection in the FITS WCS standard.
+
+  Invertibility: All ASDF tools are required to provide the inverse of
+  this transform.
+
+allOf:
+  - $ref: "transform-1.2.0"
+  - type: object
+    properties:
+      direction:
+        enum: [pix2sky, sky2pix]
+        default: pix2sky

--- a/schemas/stsci.edu/asdf/transform/identity-1.2.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/identity-1.2.0.yaml
@@ -1,0 +1,19 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/identity-1.2.0"
+tag: "tag:stsci.edu:asdf/transform/identity-1.2.0"
+title: >
+  The identity transform.
+description: >
+  Invertibility: The inverse of this transform is also the identity
+  transform.
+allOf:
+  - $ref: "transform-1.2.0"
+  - type: object
+    properties:
+      n_dims:
+        type: integer
+        default: 1
+        description: |
+          The number of dimensions.

--- a/schemas/stsci.edu/asdf/transform/label_mapper-1.2.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/label_mapper-1.2.0.yaml
@@ -1,0 +1,148 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/label_mapper-1.2.0"
+tag: "tag:stsci.edu:asdf/transform/label_mapper-1.2.0"
+title: >
+  Represents a mapping from a coordinate value to a label.
+description: |
+  A label mapper instance maps inputs to a label.  It is used together
+  with
+  [regions_selector](ref:http://stsci.edu/schemas/asdf/transform/regions_selector-1.1.0). The
+  [label_mapper](ref:http://stsci.edu/schemas/asdf/transform/label_mapper-1.2.0)
+  returns the label corresponding to given inputs. The
+  [regions_selector](ref:http://stsci.edu/schemas/asdf/transform/regions_selector-1.1.0)
+  returns the transform corresponding to this label. This maps inputs
+  (e.g. pixels on a detector) to transforms uniquely.
+
+examples:
+  -
+    - Map array indices are to labels.
+
+    - |
+        !transform/label_mapper-1.2.0
+          mapper: !core/ndarray-1.0.0
+            [[1, 0, 2],
+            [1, 0, 2],
+            [1, 0, 2]]
+
+  -
+    - Map numbers dictionary to transforms which return labels.
+
+    - |
+        !transform/label_mapper-1.2.0
+          mapper: !!omap
+          - !!omap
+            labels: [-1.67833272, -1.9580548, -1.118888]
+          - !!omap
+            models:
+          - !transform/compose-1.1.0
+            forward:
+            - !transform/remap_axes-1.1.0
+              mapping: [1]
+            - !transform/shift-1.1.0 {offset: 6.0}
+          - !transform/compose-1.1.0
+            forward:
+            - !transform/remap_axes-1.1.0
+              mapping: [1]
+            - !transform/shift-1.1.0 {offset: 2.0}
+          - !transform/compose-1.1.0
+            forward:
+            - !transform/remap_axes-1.1.0
+              mapping: [1]
+            - !transform/shift-1.1.0 {offset: 4.0}
+          inputs: [x, y]
+          inputs_mapping: !transform/remap_axes-1.1.0
+            mapping: [0]
+            n_inputs: 2
+
+  -
+    - Map a number wihtin a range of numbers to transforms which return labels.
+
+    - |
+        !transform/label_mapper-1.2.0
+          mapper: !!omap
+          - !!omap
+            labels:
+            - [3.2, 4.1]
+            - [2.67, 2.98]
+            - [1.95, 2.3]
+          - !!omap
+            models:
+          - !transform/compose-1.1.0
+            forward:
+            - !transform/remap_axes-1.1.0
+              mapping: [1]
+            - !transform/shift-1.1.0 {offset: 6.0}
+          - !transform/compose-1.1.0
+            forward:
+            - !transform/remap_axes-1.1.0
+              mapping: [1]
+            - !transform/shift-1.1.0 {offset: 2.0}
+          - !transform/compose-1.1.0
+            forward:
+            - !transform/remap_axes-1.1.0
+              mapping: [1]
+            - !transform/shift-1.1.0 {offset: 4.0}
+          inputs: [x, y]
+          inputs_mapping: !transform/remap_axes-1.1.0
+            mapping: [0]
+            n_inputs: 2
+
+allOf:
+  - $ref: "transform-1.2.0"
+  - type: object
+    properties:
+      mapper:
+        description: |
+          A mapping of inputs to labels.
+          In the general case this is a `astropy.modeling.core.Model`.
+
+          It could be a numpy array with the shape of the detector/observation.
+          Pixel values are of type integer or string and represent
+          region labels. Pixels which are not within any region have value ``no_label``.
+
+          It could be a dictionary which maps tuples to labels or floating point numbers to labels.
+
+        anyOf:
+          - $ref: "../core/ndarray-1.0.0"
+          - $ref: "transform-1.2.0"
+          - type: object
+            properties:
+              labels:
+                type: array
+                items:
+                  anyOf:
+                    - type: number
+                    - type: array
+                      items:
+                        type: number
+                      minLength: 2
+                      maxLength: 2
+              models:
+                type: array
+                items:
+                  $ref: "transform-1.2.0"
+
+      inputs:
+        type: array
+        items:
+          type: string
+        description: |
+          Names of inputs.
+      inputs_mapping:
+        $ref: "transform-1.2.0"
+        description: |
+          [mapping](ref:http://stsci.edu/schemas/asdf/transform/remap-axes-1.1.0)
+      atol:
+        type: number
+        description: |
+          absolute tolerance to compare keys in mapper.
+      no_label:
+        description: |
+          Fill in value for missing output.
+        anyOf:
+          - type: number
+          - type: string
+
+    required: [mapper]

--- a/schemas/stsci.edu/asdf/transform/multiply-1.2.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/multiply-1.2.0.yaml
@@ -1,0 +1,36 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/multiply-1.2.0"
+tag: "tag:stsci.edu:asdf/transform/multiply-1.2.0"
+title: >
+  Perform a list of subtransforms in parallel and then
+  multiply their results.
+
+description: |
+  Each of the subtransforms must have the same number of inputs and
+  outputs.
+
+  Invertibility: This transform is not automatically invertible.
+examples:
+  -
+    - A list of transforms, performed in parallel, and then combined
+      through multiplication.
+    - |
+      !transform/multiply-1.2.0
+        forward:
+          - !transform/generic-1.1.0
+            n_inputs: 1
+            n_outputs: 2
+          - !transform/generic-1.1.0
+            n_inputs: 1
+            n_outputs: 2
+
+allOf:
+  - $ref: "transform-1.2.0"
+  - properties:
+      forward:
+        type: array
+        items:
+          $ref: "transform-1.2.0"
+    required: [forward]

--- a/schemas/stsci.edu/asdf/transform/power-1.2.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/power-1.2.0.yaml
@@ -1,0 +1,23 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/power-1.2.0"
+tag: "tag:stsci.edu:asdf/transform/power-1.2.0"
+title: >
+  Perform a list of subtransforms in parallel and then raise each
+  result to the power of the next.
+
+description: |
+  Each of the subtransforms must have the same number of inputs and
+  outputs.
+
+  Invertibility: This transform is not automatically invertible.
+
+allOf:
+  - $ref: "transform-1.2.0"
+  - properties:
+      forward:
+        type: array
+        items:
+          $ref: "transform-1.2.0"
+    required: [forward]

--- a/schemas/stsci.edu/asdf/transform/pseudoconic-1.2.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/pseudoconic-1.2.0.yaml
@@ -1,0 +1,17 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/pseudoconic-1.2.0"
+title: |
+  Base class of all pseudoconic projections.
+
+description: |
+  Pseudoconics are a subclass of conics with concentric parallels.
+
+allOf:
+  - $ref: "transform-1.2.0"
+  - type: object
+    properties:
+      direction:
+        enum: [pix2sky, sky2pix]
+        default: pix2sky

--- a/schemas/stsci.edu/asdf/transform/pseudocylindrical-1.2.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/pseudocylindrical-1.2.0.yaml
@@ -1,0 +1,20 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/pseudocylindrical-1.2.0"
+title: |
+  Base class of all pseudocylindrical projections.
+
+description: |
+  Pseudocylindrical projections are like cylindrical projections
+  except the parallels of latitude are projected at diminishing
+  lengths toward the polar regions in order to reduce lateral
+  distortion there.  Consequently, the meridians are curved.
+
+allOf:
+  - $ref: "transform-1.2.0"
+  - type: object
+    properties:
+      direction:
+        enum: [pix2sky, sky2pix]
+        default: pix2sky

--- a/schemas/stsci.edu/asdf/transform/quadcube-1.2.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/quadcube-1.2.0.yaml
@@ -1,0 +1,28 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/quadcube-1.2.0"
+title: |
+  Base class of all quadcube projections.
+
+description: |
+  Quadrilateralized spherical cube (quad-cube) projections belong to
+  the class of polyhedral projections in which the sphere is projected
+  onto the surface of an enclosing polyhedron.
+
+  The six faces of the quad-cube projections are numbered and laid out
+  as:
+
+  ```
+              0
+        4 3 2 1 4 3 2
+              5
+  ```
+
+allOf:
+  - $ref: "transform-1.2.0"
+  - type: object
+    properties:
+      direction:
+        enum: [pix2sky, sky2pix]
+        default: pix2sky

--- a/schemas/stsci.edu/asdf/transform/regions_selector-1.2.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/regions_selector-1.2.0.yaml
@@ -1,0 +1,98 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/regions_selector-1.2.0"
+tag: "tag:stsci.edu:asdf/transform/regions_selector-1.2.0"
+title: >
+  Represents a discontinuous transform.
+description: |
+  Maps regions to transgorms and evaluates the transforms with the corresponding inputs.
+
+examples:
+  -
+    - Create a regions_selector schema for 2 regions, labeled "1" and "2".
+    - |
+        !transform/regions_selector-1.2.0
+          inputs: [x, y]
+          label_mapper: !transform/label_mapper-1.1.0
+            mapper: !core/ndarray-1.0.0
+              datatype: int8
+              data:
+                [[0, 1, 1, 0, 2, 0],
+                 [0, 1, 1, 0, 2, 0],
+                 [0, 1, 1, 0, 2, 0],
+                 [0, 1, 1, 0, 2, 0],
+                 [0, 1, 1, 0, 2, 0]]
+
+          outputs: [ra, dec, lam]
+          selector:
+            1: !transform/compose-1.1.0
+              forward:
+              - !transform/remap_axes-1.1.0
+                mapping: [0, 1, 1]
+              - !transform/concatenate-1.1.0
+                forward:
+                - !transform/concatenate-1.1.0
+                  forward:
+                  - !transform/shift-1.1.0 {offset: 1.0}
+                  - !transform/shift-1.1.0 {offset: 2.0}
+                - !transform/shift-1.1.0 {offset: 3.0}
+            2: !transform/compose-1.1.0
+              forward:
+              - !transform/remap_axes-1.1.0
+                mapping: [0, 1, 1]
+              - !transform/concatenate-1.1.0
+                forward:
+                - !transform/concatenate-1.1.0
+                  forward:
+                  - !transform/scale-1.1.0 {factor: 2.0}
+                  - !transform/scale-1.1.0 {factor: 3.0}
+                - !transform/scale-1.1.0 {factor: 3.0}
+          undefined_transform_value: .nan
+
+
+allOf:
+  - $ref: "transform-1.2.0"
+  - type: object
+    properties:
+      label_mapper:
+        description: |
+          An instance of
+          [label_mapper-1.1.0](ref:http://stsci.edu/schemas/asdf/transform/label_mapper-1.1.0)
+        $ref: "./label_mapper-1.1.0"
+      inputs:
+        description: |
+          Names of inputs.
+        type: array
+        items:
+          type: string
+      outputs:
+        description: |
+          Names of outputs.
+        type: array
+        items:
+          type: string
+      selector:
+        description: |
+          A mapping of regions to trransforms.
+        type: object
+        properties:
+          labels:
+            description: |
+              An array of unique region labels.
+            type: array
+            items:
+              type:
+                - integer
+                - string
+          transforms:
+            description: |
+              A transform for each region. The order should match the order of labels.
+            type: array
+            items:
+              $ref: "transform-1.2.0"
+      undefined_transform_value:
+        description: |
+          Value to be returned if there's no transform defined for the inputs.
+        type: number
+    required: [label_mapper, inputs, outputs, selector]

--- a/schemas/stsci.edu/asdf/transform/remap_axes-1.2.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/remap_axes-1.2.0.yaml
@@ -1,0 +1,92 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/remap_axes-1.2.0"
+tag: "tag:stsci.edu:asdf/transform/remap_axes-1.2.0"
+title: >
+  Reorder, add and drop axes.
+
+description: |
+  This transform allows the order of the input axes to be shuffled and
+  returned as the output axes.
+
+  It is a list made up of integers or "constant markers".  Each item
+  in the list corresponds to an output axis.  For each item:
+
+  - If an integer, it is the index of the input axis to send to the
+    output axis.
+
+  - If a constant, it must be a single item which is a constant value
+    to send to the output axis.
+
+  If only a list is provided, the number of input axes is
+  automatically determined from the maximum index in the list.  If an
+  object with `mapping` and `n_inputs` properties is provided, the
+  number of input axes is explicitly set by the `n_inputs` value.
+
+  Invertibility: TBD
+examples:
+  -
+    - For 2 input axes, swap the axes
+    - |
+        !transform/remap_axes-1.2.0
+          mapping: [1, 0]
+  -
+    - For 2 input axes, return the second axis and drop the first
+    - |
+        !transform/remap_axes-1.2.0
+          mapping: [1]
+
+  -
+    - For 2 input axes, return the first axis twice, followed by the second
+    - |
+        !transform/remap_axes-1.2.0
+          mapping: [0, 0, 1]
+
+  -
+    - For 2 input axes, add a third axis which is a constant
+    - |
+        !transform/remap_axes-1.2.0
+          mapping: [0, 1, !core/constant-1.0.0 42]
+
+  -
+    - |
+        The above example is equivalent to the following, and ASDF
+        implementations are free to normalize it thusly:
+    - |
+        !transform/concatenate-1.1.0
+          forward:
+            - !transform/remap_axes-1.2.0
+              mapping: [0]
+            - !transform/remap_axes-1.2.0
+              mapping: [1]
+            - !transform/constant-1.0.0
+              value: 42
+
+  -
+    - Here we have 3 input axes, but we are explicitly dropping the last one
+    - |
+        !transform/remap_axes-1.2.0
+          mapping: [0, 1]
+          n_inputs: 3
+
+definitions:
+  mapping:
+    type: array
+    items:
+      anyOf:
+        - type: integer
+        - $ref: "../core/constant-1.0.0"
+
+allOf:
+  - $ref: "transform-1.2.0"
+  - properties:
+      n_inputs:
+        description: |
+          Explicitly set the number of input axes.  If not provided,
+          it is determined from the maximum index value in the
+          mapping list.
+        type: integer
+      mapping:
+        $ref: "#/definitions/mapping"
+    required: [mapping]

--- a/schemas/stsci.edu/asdf/transform/rotate2d-1.3.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/rotate2d-1.3.0.yaml
@@ -1,0 +1,22 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/rotate2d-1.3.0"
+tag: "tag:stsci.edu:asdf/transform/rotate2d-1.3.0"
+title: >
+  A 2D rotation.
+description: >
+  A 2D rotation around the origin, in degrees.
+
+  Invertibility: All ASDF tools are required to be able to compute the
+  analytic inverse of this transform.
+allOf:
+  - $ref: "transform-1.2.0"
+  - type: object
+    properties:
+      angle:
+        anyOf:
+          - $ref: "../unit/quantity-1.1.0"
+          - type: number
+        description: Angle, in degrees.
+    required: [angle]

--- a/schemas/stsci.edu/asdf/transform/rotate3d-1.3.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/rotate3d-1.3.0.yaml
@@ -1,0 +1,56 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/rotate3d-1.3.0"
+tag: "tag:stsci.edu:asdf/transform/rotate3d-1.3.0"
+title: >
+  Rotation in 3D space.
+description: |
+  Euler angle rotation around 3 axes.
+
+  Invertibility: All ASDF tools are required to be able to compute the
+  analytic inverse of this transform.
+
+examples:
+  -
+    - The three Euler angles are 12.3, 34 and -1.2 in degrees.
+    - |
+      !transform/rotate3d-1.3.0
+        phi: 12.3
+        theta: 34
+        psi: -1.2
+        direction: zxz
+
+allOf:
+  - $ref: "transform-1.2.0"
+  - type: object
+    properties:
+      phi:
+        anyOf:
+          - $ref: "../unit/quantity-1.1.0"
+          - type: number
+        description: Angle, in degrees.
+      theta:
+        anyOf:
+          - $ref: "../unit/quantity-1.1.0"
+          - type: number
+        description: Angle, in degrees.
+      psi:
+        anyOf:
+          - $ref: "../unit/quantity-1.1.0"
+          - type: number
+        description: Angle, in degrees.
+      direction:
+        description: |
+          Sequence of rotation axes: one of `zxz`, `zyz`, `yzy`, `yxy`, `xyx`, `xzx`
+          or `native2celestial`, `celestial2native`.
+
+          If `direction` is `native2celestial` or `celestial2native`,
+          `phi`, `theta` are the longitude and latitude of the native pole in
+          the celestial system and `psi` is the longitude of the celestial pole in
+          the native system.
+
+        enum: [zxz, zyz, yzy, yxy, xyx, xzx, native2celestial, celestial2native]
+        default: native2celestial
+
+    required: [phi, theta, psi, direction]

--- a/schemas/stsci.edu/asdf/transform/subtract-1.2.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/subtract-1.2.0.yaml
@@ -1,0 +1,36 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/subtract-1.2.0"
+tag: "tag:stsci.edu:asdf/transform/subtract-1.2.0"
+title: >
+  Perform a list of subtransforms in parallel and then
+  subtract their results.
+
+description: |
+  Each of the subtransforms must have the same number of inputs and
+  outputs.
+
+  Invertibility: This transform is not automatically invertible.
+examples:
+  -
+    - A list of transforms, performed in parallel, and then combined
+      through subtraction.
+    - |
+      !transform/subtract-1.2.0
+        forward:
+          - !transform/generic-1.1.0
+            n_inputs: 1
+            n_outputs: 2
+          - !transform/generic-1.1.0
+            n_inputs: 1
+            n_outputs: 2
+
+allOf:
+  - $ref: "transform-1.2.0"
+  - properties:
+      forward:
+        type: array
+        items:
+          $ref: "transform-1.2.0"
+    required: [forward]

--- a/schemas/stsci.edu/asdf/transform/transform-1.2.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/transform-1.2.0.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
+title: >
+  A generic type used to mark where other transforms are accepted.
+
+description: >
+  These objects are designed to be nested in arbitrary ways to build up
+  transformation pipelines out of a number of low-level pieces.
+
+type: object
+properties:
+  name:
+    description: |
+      A user-friendly name for the transform, to give it extra
+      meaning.
+    type: string
+
+  inverse:
+    description: |
+      Explicitly sets the inverse transform of this transform.
+
+      If the transform has a direct analytic inverse, this
+      property is usually not necessary, as the ASDF-reading tool
+      can provide it automatically.
+
+    $ref: "transform-1.2.0"
+additionalProperties: true

--- a/schemas/stsci.edu/asdf/transform/zenithal-1.2.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/zenithal-1.2.0.yaml
@@ -1,0 +1,28 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/zenithal-1.2.0"
+title: |
+  Base class of all zenithal (or azimuthal) projections.
+
+description: |
+  Zenithal projections are completely specified by defining the radius
+  as a function of native latitude, $R_\theta$.
+
+  The pixel-to-sky transformation is defined as:
+
+  $$\phi &= \arg(-y, x) \\
+  R_\theta &= \sqrt{x^2 + y^2}$$
+
+  and the inverse (sky-to-pixel) is defined as:
+
+  $$x &= R_\theta \sin \phi \\
+  y &= R_\theta \cos \phi$$
+
+allOf:
+  - $ref: "transform-1.2.0"
+  - type: object
+    properties:
+      direction:
+        enum: [pix2sky, sky2pix]
+        default: pix2sky

--- a/schemas/stsci.edu/asdf/version_map-1.2.0.yaml
+++ b/schemas/stsci.edu/asdf/version_map-1.2.0.yaml
@@ -63,7 +63,7 @@ tags:
   tag:stsci.edu:asdf/transform/subtract: 1.1.0
   tag:stsci.edu:asdf/transform/tabular: 1.2.0
   tag:stsci.edu:asdf/transform/tangential_spherical_cube: 1.1.0
-  tag:stsci.edu:asdf/transform/transform: 1.1.0
+  tag:stsci.edu:asdf/transform/transform: 1.2.0
   tag:stsci.edu:asdf/transform/zenithal: 1.1.0
   tag:stsci.edu:asdf/transform/zenithal_equal_area: 1.1.0
   tag:stsci.edu:asdf/transform/zenithal_equidistant: 1.1.0

--- a/schemas/stsci.edu/asdf/wcs/step-1.2.0.yaml
+++ b/schemas/stsci.edu/asdf/wcs/step-1.2.0.yaml
@@ -1,0 +1,31 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/wcs/step-1.2.0"
+tag: "tag:stsci.edu:asdf/wcs/step-1.2.0"
+title: >
+  Describes a single step of a WCS transform pipeline.
+description: >
+examples: []
+
+type: object
+properties:
+  frame:
+    description: |
+      The frame of the inputs to the transform.
+    anyOf:
+      - type: string
+      - $ref: frame-1.1.0
+
+  transform:
+    description: |
+      The transform from this step to the next one.  The
+      last step in a WCS should not have a transform, but
+      exists only to describe the frames and units of the
+      final output axes.
+    anyOf:
+      - $ref: ../transform/transform-1.2.0
+      - type: 'null'
+    default: null
+
+required: [frame]

--- a/schemas/stsci.edu/asdf/wcs/wcs-1.2.0.yaml
+++ b/schemas/stsci.edu/asdf/wcs/wcs-1.2.0.yaml
@@ -1,0 +1,32 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/wcs/wcs-1.2.0"
+tag: "tag:stsci.edu:asdf/wcs/wcs-1.2.0"
+title: >
+  A system for describing generalized world coordinate transformations.
+description: >
+  ASDF WCS is a way of specifying transformations (usually from
+  detector space to world coordinate space and back) by using the
+  transformations in the `transform-schema` module.
+type: object
+properties:
+  name:
+    description: |
+      A descriptive name for this WCS.
+    type: string
+
+  steps:
+    description: |
+      A list of steps in the forward transformation from detector to
+      world coordinates.
+      The inverse transformation is determined automatically by
+      reversing this list, and inverting each of the individual
+      transforms according to the rules described in
+      [inverse](ref:http://stsci.edu/schemas/asdf/transform/transform-1.2.0/properties/inverse).
+    type: array
+    items:
+      $ref: step-1.1.0
+
+required: [name, steps]
+additionalProperties: true

--- a/update-schemas.py
+++ b/update-schemas.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+import os
+import re
+import sys
+import subprocess as sp
+
+
+def get_schemas(pattern):
+
+    cmd = ['git', 'grep', '--name-only']
+    output = sp.check_output(cmd + [pattern, '--', 'schemas']).decode('utf8')
+    names = output.split()
+    print(names)
+
+    dedupe = dict()
+
+    for name in names:
+        version = re.findall(r'\d\.\d.\d', name)[0]
+        basepath = name.split('-')[0]
+        if basepath in dedupe and dedupe[basepath] > version:
+            continue
+
+        dedupe[basepath] = version
+
+    return ['{}-{}.yaml'.format(x, y) for x,y in dedupe.items()]
+
+
+def update_version(string):
+
+    groups = re.search(r'((\d)\.(\d)\.(\d))', string).groups()
+    bumped = int(groups[2]) + 1
+
+    new_version = '{}.{}.{}'.format(groups[1], bumped, groups[3])
+    return re.sub(r'((\d)\.(\d)\.(\d))', new_version, string)
+
+
+def create_updated_schema(schema, pattern, new_pattern):
+
+    name = os.path.splitext(os.path.basename(schema))[0]
+    updated = update_version(name)
+    new_schema = re.sub(name, updated, schema)
+
+    with open(new_schema, 'w') as new_file:
+        with open(schema, 'r') as old_file:
+            for line in old_file:
+                line = line.replace(pattern, new_pattern)
+                line = line.replace(name, updated)
+                new_file.write(line)
+
+
+def main():
+
+    if len(sys.argv) != 2:
+        name = os.path.basename(sys.argv[0])
+        sys.stderr.write('USAGE: {} <pattern>\n'.format(name))
+        exit(1)
+
+    pattern = sys.argv[1]
+    new_pattern = update_version(pattern)
+    schemas = get_schemas(pattern)
+
+    for s in schemas:
+        create_updated_schema(s, pattern, new_pattern)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This seems to me more of a bug fix since `domain` wasn't even included in version 1.2.0 of the standard. If this is the case, we shouldn't actually need to bump the version number of `transform`, which means we can avoid a cascade of changes throughout the rest of the transform schemas.