### PR TITLE
Prevent conftest from being used as submodule

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,7 @@
-pytest_plugins = [
-    'asdf.tests.schema_tester'
-]
+import os
+
+# Only add this plugin definition when not being run as part of a submodule
+if os.path.dirname(__file__) == os.path.abspath(os.curdir):
+    pytest_plugins = [
+        'asdf.tests.schema_tester'
+    ]


### PR DESCRIPTION
This prevents a warning from occurring with newer versions of `pytest` when running the test suite of the ASDF package.