### PR TITLE
Skip examples that are no longer supported by Python ASDF

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,4 @@
 [tool:pytest]
 asdf_schema_root = schemas
 asdf_schema_skip_names = asdf-schema-1.0.0 draft-01
+asdf_schema_skip_examples = domain-1.0.0 frame-1.0.0 frame-1.1.0


### PR DESCRIPTION
Since some tags were removed in `asdf-2.3.0`, and since we rely on the Python implementation of `asdf` for testing schema examples, we need to reflect those removals here.