### PR TITLE
Fix malformed reference in ASDF schema

### DIFF
--- a/schemas/stsci.edu/asdf/asdf-schema-1.0.0.yaml
+++ b/schemas/stsci.edu/asdf/asdf-schema-1.0.0.yaml
@@ -36,7 +36,7 @@ allOf:
           can be cast to the given datatype without data loss.  For
           exact datatype matching, set `exact_datatype` to `true`.
         allOf:
-          - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0#/definitions/datatype-1.0.0"
+          - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0#/definitions/datatype"
 
       exact_datatype:
         description: |


### PR DESCRIPTION
This is a fairly minor, but significant, bug. It was discovered by the JWST pipeline after meta-schema validation was fixed in the `asdf` package (see https://github.com/spacetelescope/asdf/pull/654).

I'm deciding not to bump any version numbers here because:
1. That would lead to a significant cascade of changes across multiple packages.
2. While the bug is significant, this is the first time it ever appears to have manifested, even though this file was last modified nearly 4 years ago.

cc @nden @jdavies-st 