### PR TITLE
Do not use autosectionlabel plugin

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -30,7 +30,7 @@ import sphinx_bootstrap_theme
 mathjax_path="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
 extensions = [
     'sphinx.ext.mathjax', 'sphinx.ext.ifconfig', 'sphinx.ext.graphviz',
-    'sphinxext.category', 'sphinx.ext.autosectionlabel', 'sphinx_asdf'
+    'sphinxext.category', 'sphinx_asdf'
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
This is no longer necessary due to updates in `sphinx-asdf`: https://github.com/spacetelescope/sphinx-asdf/pull/3. The main motivation was that the `autosectionlabel` plugin appeared to be causing conflicts with the `automodapi` plugin provided by Astropy, which is used by many of our packages.