### PR TITLE
Fix label mapper examples

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,6 @@
 import os
+from pkgutil import find_loader
+
 import asdf
 from asdf import resolver as res
 
@@ -18,6 +20,8 @@ if DIRNAME == os.path.abspath(os.curdir):
     res.default_url_mapping = res.Resolver(ASDF_SCHEMA_URL_MAPPING, 'url')
 
     # Only add this plugin definition when not being run as part of a submodule
-    pytest_plugins = [
-        'asdf.tests.schema_tester'
-    ]
+    # Account for the fact that asdf-2.4.0 and later registers the plugin as an
+    # entry point, and this module no longer exists. But we want to retain
+    # backwards compatibility with older versions.
+    if find_loader('asdf.tests.schema_tester'):
+        pytest_plugins = ['asdf.tests.schema_tester' ]

--- a/schemas/stsci.edu/asdf/transform/label_mapper-1.0.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/label_mapper-1.0.0.yaml
@@ -36,21 +36,21 @@ examples:
             labels: [-1.67833272, -1.9580548, -1.118888]
           - !!omap
             models:
-          - !transform/compose-1.0.0
-            forward:
-            - !transform/remap_axes-1.0.0
-              mapping: [1]
-            - !transform/shift-1.0.0 {offset: 6.0}
-          - !transform/compose-1.0.0
-            forward:
-            - !transform/remap_axes-1.0.0
-              mapping: [1]
-            - !transform/shift-1.0.0 {offset: 2.0}
-          - !transform/compose-1.0.0
-            forward:
-            - !transform/remap_axes-1.0.0
-              mapping: [1]
-            - !transform/shift-1.0.0 {offset: 4.0}
+            - !transform/compose-1.0.0
+              forward:
+              - !transform/remap_axes-1.0.0
+                mapping: [1]
+              - !transform/shift-1.0.0 {offset: 6.0}
+            - !transform/compose-1.0.0
+              forward:
+              - !transform/remap_axes-1.0.0
+                mapping: [1]
+              - !transform/shift-1.0.0 {offset: 2.0}
+            - !transform/compose-1.0.0
+              forward:
+              - !transform/remap_axes-1.0.0
+                mapping: [1]
+              - !transform/shift-1.0.0 {offset: 4.0}
           inputs: [x, y]
           inputs_mapping: !transform/remap_axes-1.0.0
             mapping: [0]
@@ -69,21 +69,21 @@ examples:
             - [1.95, 2.3]
           - !!omap
             models:
-          - !transform/compose-1.0.0
-            forward:
-            - !transform/remap_axes-1.0.0
-              mapping: [1]
-            - !transform/shift-1.0.0 {offset: 6.0}
-          - !transform/compose-1.0.0
-            forward:
-            - !transform/remap_axes-1.0.0
-              mapping: [1]
-            - !transform/shift-1.0.0 {offset: 2.0}
-          - !transform/compose-1.0.0
-            forward:
-            - !transform/remap_axes-1.0.0
-              mapping: [1]
-            - !transform/shift-1.0.0 {offset: 4.0}
+            - !transform/compose-1.0.0
+              forward:
+              - !transform/remap_axes-1.0.0
+                mapping: [1]
+              - !transform/shift-1.0.0 {offset: 6.0}
+            - !transform/compose-1.0.0
+              forward:
+              - !transform/remap_axes-1.0.0
+                mapping: [1]
+              - !transform/shift-1.0.0 {offset: 2.0}
+            - !transform/compose-1.0.0
+              forward:
+              - !transform/remap_axes-1.0.0
+                mapping: [1]
+              - !transform/shift-1.0.0 {offset: 4.0}
           inputs: [x, y]
           inputs_mapping: !transform/remap_axes-1.0.0
             mapping: [0]

--- a/schemas/stsci.edu/asdf/transform/label_mapper-1.1.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/label_mapper-1.1.0.yaml
@@ -36,21 +36,21 @@ examples:
             labels: [-1.67833272, -1.9580548, -1.118888]
           - !!omap
             models:
-          - !transform/compose-1.1.0
-            forward:
-            - !transform/remap_axes-1.1.0
-              mapping: [1]
-            - !transform/shift-1.1.0 {offset: 6.0}
-          - !transform/compose-1.1.0
-            forward:
-            - !transform/remap_axes-1.1.0
-              mapping: [1]
-            - !transform/shift-1.1.0 {offset: 2.0}
-          - !transform/compose-1.1.0
-            forward:
-            - !transform/remap_axes-1.1.0
-              mapping: [1]
-            - !transform/shift-1.1.0 {offset: 4.0}
+            - !transform/compose-1.1.0
+              forward:
+              - !transform/remap_axes-1.1.0
+                mapping: [1]
+              - !transform/shift-1.1.0 {offset: 6.0}
+            - !transform/compose-1.1.0
+              forward:
+              - !transform/remap_axes-1.1.0
+                mapping: [1]
+              - !transform/shift-1.1.0 {offset: 2.0}
+            - !transform/compose-1.1.0
+              forward:
+              - !transform/remap_axes-1.1.0
+                mapping: [1]
+              - !transform/shift-1.1.0 {offset: 4.0}
           inputs: [x, y]
           inputs_mapping: !transform/remap_axes-1.1.0
             mapping: [0]
@@ -69,21 +69,21 @@ examples:
             - [1.95, 2.3]
           - !!omap
             models:
-          - !transform/compose-1.1.0
-            forward:
-            - !transform/remap_axes-1.1.0
-              mapping: [1]
-            - !transform/shift-1.1.0 {offset: 6.0}
-          - !transform/compose-1.1.0
-            forward:
-            - !transform/remap_axes-1.1.0
-              mapping: [1]
-            - !transform/shift-1.1.0 {offset: 2.0}
-          - !transform/compose-1.1.0
-            forward:
-            - !transform/remap_axes-1.1.0
-              mapping: [1]
-            - !transform/shift-1.1.0 {offset: 4.0}
+            - !transform/compose-1.1.0
+              forward:
+              - !transform/remap_axes-1.1.0
+                mapping: [1]
+              - !transform/shift-1.1.0 {offset: 6.0}
+            - !transform/compose-1.1.0
+              forward:
+              - !transform/remap_axes-1.1.0
+                mapping: [1]
+              - !transform/shift-1.1.0 {offset: 2.0}
+            - !transform/compose-1.1.0
+              forward:
+              - !transform/remap_axes-1.1.0
+                mapping: [1]
+              - !transform/shift-1.1.0 {offset: 4.0}
           inputs: [x, y]
           inputs_mapping: !transform/remap_axes-1.1.0
             mapping: [0]

--- a/schemas/stsci.edu/asdf/transform/label_mapper-1.2.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/label_mapper-1.2.0.yaml
@@ -36,21 +36,21 @@ examples:
             labels: [-1.67833272, -1.9580548, -1.118888]
           - !!omap
             models:
-          - !transform/compose-1.1.0
-            forward:
-            - !transform/remap_axes-1.1.0
-              mapping: [1]
-            - !transform/shift-1.1.0 {offset: 6.0}
-          - !transform/compose-1.1.0
-            forward:
-            - !transform/remap_axes-1.1.0
-              mapping: [1]
-            - !transform/shift-1.1.0 {offset: 2.0}
-          - !transform/compose-1.1.0
-            forward:
-            - !transform/remap_axes-1.1.0
-              mapping: [1]
-            - !transform/shift-1.1.0 {offset: 4.0}
+            - !transform/compose-1.1.0
+              forward:
+              - !transform/remap_axes-1.1.0
+                mapping: [1]
+              - !transform/shift-1.1.0 {offset: 6.0}
+            - !transform/compose-1.1.0
+              forward:
+              - !transform/remap_axes-1.1.0
+                mapping: [1]
+              - !transform/shift-1.1.0 {offset: 2.0}
+            - !transform/compose-1.1.0
+              forward:
+              - !transform/remap_axes-1.1.0
+                mapping: [1]
+              - !transform/shift-1.1.0 {offset: 4.0}
           inputs: [x, y]
           inputs_mapping: !transform/remap_axes-1.1.0
             mapping: [0]
@@ -69,21 +69,21 @@ examples:
             - [1.95, 2.3]
           - !!omap
             models:
-          - !transform/compose-1.1.0
-            forward:
-            - !transform/remap_axes-1.1.0
-              mapping: [1]
-            - !transform/shift-1.1.0 {offset: 6.0}
-          - !transform/compose-1.1.0
-            forward:
-            - !transform/remap_axes-1.1.0
-              mapping: [1]
-            - !transform/shift-1.1.0 {offset: 2.0}
-          - !transform/compose-1.1.0
-            forward:
-            - !transform/remap_axes-1.1.0
-              mapping: [1]
-            - !transform/shift-1.1.0 {offset: 4.0}
+            - !transform/compose-1.1.0
+              forward:
+              - !transform/remap_axes-1.1.0
+                mapping: [1]
+              - !transform/shift-1.1.0 {offset: 6.0}
+            - !transform/compose-1.1.0
+              forward:
+              - !transform/remap_axes-1.1.0
+                mapping: [1]
+              - !transform/shift-1.1.0 {offset: 2.0}
+            - !transform/compose-1.1.0
+              forward:
+              - !transform/remap_axes-1.1.0
+                mapping: [1]
+              - !transform/shift-1.1.0 {offset: 4.0}
           inputs: [x, y]
           inputs_mapping: !transform/remap_axes-1.1.0
             mapping: [0]

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,4 @@
 asdf_schema_root = schemas
 asdf_schema_skip_names = asdf-schema-1.0.0 draft-01
 asdf_schema_skip_examples = domain-1.0.0 frame-1.0.0 frame-1.1.0
+asdf_schema_tests_enabled = true


### PR DESCRIPTION
These seem to have been malformed for quite some time, but it's not clear exactly why the tests were passing anyway. This issue was discovered in the course of updating the asdf package to use `ruamel.yaml` instead of `pyyaml`. It appears that `ruamel.yaml` provides proper support
for `omap` whereas `pyyaml` did not (see https://github.com/yaml/pyyaml/issues/78).

This also makes updates related to changes to the schema tester plugin made in https://github.com/spacetelescope/asdf/pull/676.
