### PR TITLE
Fix bug in YAML Schema for validating example sections

### DIFF
--- a/schemas/stsci.edu/yaml-schema/draft-01.yaml
+++ b/schemas/stsci.edu/yaml-schema/draft-01.yaml
@@ -99,6 +99,10 @@ allOf:
 
         type: array
         items:
-          - type: string
-          - type: string
+          type: array
+          items:
+            - type: string
+            - anyOf:
+              - type: string
+              - type: object
 ...


### PR DESCRIPTION
This came to light when attempting to update the `asdf-standard` submodule in the ASDF package in preparation for the 2.4.0 release: https://github.com/spacetelescope/asdf/pull/678