### PR TITLE
add fix_inputs schema

### DIFF
--- a/schemas/stsci.edu/asdf/transform/fix_inputs-1.0.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/fix_inputs-1.0.0.yaml
@@ -1,0 +1,39 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/set_inputs-1.0.0"
+tag: "tag:stsci.edu:asdf/transform/set_inputs-1.0.0"
+title: >
+  Set to a constant selected input arguments of a model.
+
+description: |
+ This operation takes as the right hand side a dict equivalent
+ that consists of key:value pairs where the key identifies 
+ the input argument to be set, either by position number
+ (0 based) or name, and the value is the floating point value
+ that should be assigned to that input. The result is a 
+ compound model with n fewer input arguments where n is 
+ the number of input values to be set (i.e., the number
+ of keys in the dict).
+
+examples:
+    - !transform/set_input-1.0.0
+        forward:
+          - !transform/generic-1.1.0
+            n_inputs: 3
+            n_outputs: 2
+          - 
+            x: 7.3
+
+allOf:
+  - $ref: "transform-1.1.0"
+  - properties:
+      forward:
+        type: array
+        items:
+          - $ref: "transform-1.1.0"
+          - type: object
+            minProperties: 1
+        minItems: 2
+        maxItems: 2
+    required: [forward]


### PR DESCRIPTION
This adds the schema to support the fix_inputs operation in modeling compound models.