### PR TITLE
add a schema for fix_input operator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ env:
     - secure: "W3PaYhPnJFCaG6TW5Xc0wtggdEqcreTQcHThmIo5Eqs/jUL2toiUiv3ZWlhzR3tkphLvt2KeaQe83BR6RTifYjSmnmAePj0Gw5res1AXzN95OsKEk3nMiTZbVP+PuTTbQZJga8B31nRUBiAMQ6FsNlpGq7E8sp9N65lnR3mGHAE="
     - PIP_DOC_DEPENDENCIES="six sphinx sphinx_bootstrap_theme sphinx-asdf"
     - ASDF_MASTER="git+git://github.com/spacetelescope/asdf"
+    - ASTROPY_MASTER="git+git://github.com/astropy/astropy"
 
 sudo: false
 
@@ -32,6 +33,8 @@ matrix:
         - pip install $ASDF_MASTER pytest
         # We need to install these packages because they contain the canonical
         # implementations for some of the schemas we need to test
-        - pip install astropy gwcs
+        ## - pip install astropy gwcs
+        # test temporarily with astropy master to pick up new transform tags
+        pip install $ASTROPY_MASTER gwcs
       install: echo Nothing to install
       script: pytest

--- a/schemas/stsci.edu/asdf/transform/fix_inputs-1.1.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/fix_inputs-1.1.0.yaml
@@ -1,0 +1,62 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/fix_inputs-1.1.0"
+tag: "tag:stsci.edu:asdf/transform/fix_inputs-1.1.0"
+title: >
+  Set to a constant selected input arguments of a model.
+
+description: |
+  This operation takes as the right hand side a dict equivalent
+  that consists of key:value pairs where the key identifies
+  the input argument to be set, either by position number
+  (0 based) or name, and the value is the floating point value
+  that should be assigned to that input. The result is a
+  compound model with n fewer input arguments where n is
+  the number of input values to be set (i.e., the number
+  of keys in the dict).
+
+examples:
+  -
+    - Fix the 0-th coordinate.
+    - |
+      !transform/fix_inputs-1.1.0
+        forward:
+        - !transform/compose-1.1.0
+            forward:
+            - !transform/gnomonic-1.1.0 {direction: pix2sky}
+            - !transform/rotate2d-1.2.0 {angle: 23.0}
+        - keys: [0]
+          values: [2]
+  -
+    - Fix the "x" coordinate.
+    - |
+      !transform/fix_inputs-1.1.0
+        forward:
+        - !transform/compose-1.1.0
+            forward:
+            - !transform/gnomonic-1.1.0 {direction: pix2sky}
+            - !transform/rotate2d-1.2.0 {angle: 23.0}
+        - keys: [x]
+          values: [2]
+
+allOf:
+  - $ref: "transform-1.1.0"
+  - properties:
+      forward:
+        type: array
+        items:
+          - $ref: "transform-1.1.0"
+          - type: object
+            properties:
+              keys:
+                type: array
+                items:
+                  type: [string, integer]
+              values:
+                type: array
+                items:
+                  - type: number
+        minItems: 2
+        maxItems: 2
+    required: [forward]

--- a/schemas/stsci.edu/asdf/version_map-1.4.0.yaml
+++ b/schemas/stsci.edu/asdf/version_map-1.4.0.yaml
@@ -33,6 +33,7 @@ tags:
   tag:stsci.edu:asdf/transform/cylindrical_equal_area: 1.2.0
   tag:stsci.edu:asdf/transform/cylindrical_perspective: 1.2.0
   tag:stsci.edu:asdf/transform/divide: 1.1.0
+  tag:stsci.edu:asdf/transform/fix_inputs: 1.1.0
   tag:stsci.edu:asdf/transform/generic: 1.1.0
   tag:stsci.edu:asdf/transform/gnomonic: 1.1.0
   tag:stsci.edu:asdf/transform/hammer_aitoff: 1.1.0


### PR DESCRIPTION
Adds schema for the "fix_inputs" operator in astropy.modeling. The corresponding tag is implemented in astropy/astropy#9135.