### PR TITLE
add grating equation schema

### DIFF
--- a/schemas/stsci.edu/asdf/transform/grating_equation-1.0.0.yaml
+++ b/schemas/stsci.edu/asdf/transform/grating_equation-1.0.0.yaml
@@ -1,0 +1,52 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/grating_equation-1.0.0"
+tag: "tag:stsci.edu:asdf/transform/grating_equation-1.0.0"
+title: >
+  A grating equation model.
+
+description: |
+  Supports two models:
+   - Given incident angle and wavelength compute the refraction/difraction angle.
+   - Given an incident angle and a refraction angle compute the wavelength.
+
+Examples:
+  -
+    - AnglesFromGratingEquation model.
+
+    - |
+        !<tag:stsci.edu:asdf/transform/grating_equation-1.0.0>
+          groove_density: 2700.0
+          order: 2.0
+          output: angle
+
+  -
+    - WavelengthFromGratingEquation model.
+
+    - |
+        !<tag:stsci.edu:asdf/transform/grating_equation-1.0.0>
+          groove_density: 2700.0
+          order: 2.0
+          output: wavelength
+
+allOf:
+  - $ref: "transform-1.1.0"
+  - type: object
+    properties:
+      groove_density:
+        description: |
+          The groove density of the grating
+        anyOf:
+          - type: number
+          - $ref: "../unit/quantity-1.1.0"
+      order:
+        description: |
+          Spectral order
+        type: number
+      output:
+        type: string
+        description: |
+          indicates which quantity the grating equation is solved for.
+        enum: [wavelength, angle]
+    required: [groove_density, order, output]

--- a/schemas/stsci.edu/asdf/version_map-1.4.0.yaml
+++ b/schemas/stsci.edu/asdf/version_map-1.4.0.yaml
@@ -36,6 +36,7 @@ tags:
   tag:stsci.edu:asdf/transform/fix_inputs: 1.1.0
   tag:stsci.edu:asdf/transform/generic: 1.1.0
   tag:stsci.edu:asdf/transform/gnomonic: 1.1.0
+  tag:stsci.edu:asdf/transform/grating_equation: 1.0.0
   tag:stsci.edu:asdf/transform/hammer_aitoff: 1.1.0
   tag:stsci.edu:asdf/transform/healpix: 1.1.0
   tag:stsci.edu:asdf/transform/healpix_polar: 1.1.0


### PR DESCRIPTION
Adds a schema for a grating equation model. Two models in astropy will use it: `WavelengthFromGratingEquation` and `AnglesFromGratingEquation`.