### PR TITLE
Add subclass_metadata-1.0.0.yaml schema

### DIFF
--- a/schemas/stsci.edu/asdf/core/subclass_metadata-1.0.0.yaml
+++ b/schemas/stsci.edu/asdf/core/subclass_metadata-1.0.0.yaml
@@ -13,7 +13,8 @@ type: object
 properties:
   name:
     description: |
-      The name of the subclass to deserialize.
+      The name of the subclass that represents this object
+      when deserialized.
     type: string
 
 required: [name]

--- a/schemas/stsci.edu/asdf/core/subclass_metadata-1.0.0.yaml
+++ b/schemas/stsci.edu/asdf/core/subclass_metadata-1.0.0.yaml
@@ -1,0 +1,20 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/core/subclass_metadata-1.0.0"
+title: |
+  Metadata on a serialized subclass of an ASDF-enabled type.
+description: |
+  Identifies the specific subclass that was serialized,
+  to enable ASDF readers to correctly deserialize the object.
+
+tag: "tag:stsci.edu:asdf/core/subclass_metadata-1.0.0"
+type: object
+properties:
+  name:
+    description: |
+      The name of the subclass to deserialize.
+    type: string
+
+required: [name]
+...

--- a/schemas/stsci.edu/asdf/version_map-1.4.0.yaml
+++ b/schemas/stsci.edu/asdf/version_map-1.4.0.yaml
@@ -13,6 +13,7 @@ tags:
   tag:stsci.edu:asdf/core/integer: 1.0.0
   tag:stsci.edu:asdf/core/ndarray: 1.0.0
   tag:stsci.edu:asdf/core/software: 1.0.0
+  tag:stsci.edu:asdf/core/subclass_metadata: 1.0.0
   tag:stsci.edu:asdf/core/table: 1.0.0
   tag:stsci.edu:asdf/fits/fits: 1.0.0
   tag:stsci.edu:asdf/time/time: 1.1.0


### PR DESCRIPTION
The Python ASDF library references a core schema called subclass_metadata, but it doesn't exist yet.  This PR adds that missing schema.

Resolves https://github.com/spacetelescope/asdf/issues/748