### PR TITLE
Change asdf-schema to point to URI instead of tag

### DIFF
--- a/schemas/stsci.edu/asdf/asdf-schema-1.0.0.yaml
+++ b/schemas/stsci.edu/asdf/asdf-schema-1.0.0.yaml
@@ -36,7 +36,7 @@ allOf:
           can be cast to the given datatype without data loss.  For
           exact datatype matching, set `exact_datatype` to `true`.
         allOf:
-          - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0#/definitions/datatype"
+          - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0#/definitions/datatype"
 
       exact_datatype:
         description: |


### PR DESCRIPTION
`$ref` values are intended to be URIs, and it's only a quirk of the Python library that tags work at all.  This should also be a test in the schema validation plugin -- I'll add an issue and pursue that at some point.