### PR TITLE
Ignore unrecognized tag warnings in schema tests in this repo

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,19 +1,29 @@
 import os
 
 import asdf
-from asdf import resolver as res
+from asdf import extension
+
 
 DIRNAME = os.path.dirname(__file__)
 
+# Check if we're running tests from the current directory.
 if DIRNAME == os.path.abspath(os.curdir):
-    # Override the default ASDF url mapping so that all ASDF Standard schemas
+    # Override the ASDF BuiltinExtension so that all ASDF Standard schemas
     # resolve to the ones that are present in this repository, rather than
     # those that are installed with the ASDF python package. This allows for
     # much more direct testing of changes to schemas in this repository.
-    ASDF_SCHEMA_URL_MAPPING = [
+    local_url_mapping = [
         (
             asdf.constants.STSCI_SCHEMA_URI_BASE,
             asdf.util.filepath_to_url(os.path.join(DIRNAME, "schemas", "stsci.edu")) + "/{url_suffix}.yaml",
         )
     ]
-    res.default_url_mapping = res.Resolver(ASDF_SCHEMA_URL_MAPPING, "url")
+
+    class LocalBuiltinExtension(extension.BuiltinExtension):
+        @property
+        def url_mapping(self):
+            return local_url_mapping
+
+    exts = extension.default_extensions.extensions
+    exts.clear()
+    exts.append(LocalBuiltinExtension())

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ asdf_schema_root = schemas
 asdf_schema_skip_names = asdf-schema-1.0.0 draft-01
 asdf_schema_skip_examples = domain-1.0.0 frame-1.0.0 frame-1.1.0
 asdf_schema_tests_enabled = true
+asdf_schema_ignore_unrecognized_tag = true
 
 [flake8]
 ignore = E501, E203, W503

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,7 @@
 pytest
 pyyaml
-asdf
+# This is set to master to make the pytest plugin's asdf_schema_ignore_unrecognized_tag
+# option available.  We can switch back to PyPI once asdf 2.6.0 is released.
+git+https://github.com/spacetelescope/asdf.git
 astropy
 gwcs


### PR DESCRIPTION
This PR fixes the default resolver override in conftest.py that was broken by changes to resolver code in asdf.  It also disables warnings on unrecognized objects when deserializing schema examples in tests.

These changes will allow the tests to function when new schemas are added to this repo.