### PR TITLE
Remove deprecated wcs schemas from 1.5.0

### DIFF
--- a/schemas/stsci.edu/asdf/version_map-1.5.0.yaml
+++ b/schemas/stsci.edu/asdf/version_map-1.5.0.yaml
@@ -100,10 +100,4 @@ tags:
   tag:stsci.edu:asdf/unit/defunit: 1.0.0
   tag:stsci.edu:asdf/unit/quantity: 1.1.0
   tag:stsci.edu:asdf/unit/unit: 1.0.0
-  tag:stsci.edu:asdf/wcs/celestial_frame: 1.1.0
-  tag:stsci.edu:asdf/wcs/composite_frame: 1.1.0
-  tag:stsci.edu:asdf/wcs/icrs_coord: 1.1.0
-  tag:stsci.edu:asdf/wcs/spectral_frame: 1.1.0
-  tag:stsci.edu:asdf/wcs/step: 1.2.0
-  tag:stsci.edu:asdf/wcs/wcs: 1.2.0
 ...

--- a/tests/common.py
+++ b/tests/common.py
@@ -16,7 +16,15 @@ VALID_FILE_FORMAT_VERSIONS = {"1.0.0"}
 
 VALID_SCHEMA_FILENAME_RE = re.compile(r"[a-z0-9_]+-[0-9]+\.[0-9]+\.[0-9]+\.yaml")
 
-DEPRECATED_NAMES = {"transform/domain"}
+DEPRECATED_NAMES = {
+    "transform/domain",
+    "wcs/celestial_frame",
+    "wcs/composite_frame",
+    "wcs/icrs_coord",
+    "wcs/spectral_frame",
+    "wcs/step",
+    "wcs/wcs",
+}
 DEPRECATED_ID_BASES = {f"http://stsci.edu/schemas/asdf/{name}" for name in DEPRECATED_NAMES}
 DEPRECATED_TAG_BASES = {f"tag:stsci.edu:asdf/{name}" for name in DEPRECATED_NAMES}
 


### PR DESCRIPTION
These schemas have moved to gwcs and aren't needed in the next version of the standard.