### PR TITLE
skip 2 ndarray examples

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,8 @@ asdf_schema_skip_tests = """
     stsci.edu/asdf/wcs/wcs-1.1.0.yaml
     stsci.edu/asdf/wcs/wcs-1.2.0.yaml
     stsci.edu/yaml-schema/draft-01.yaml
+    stsci.edu/asdf/core/ndarray-1.1.0.yaml::test_example_8
+    stsci.edu/asdf/core/ndarray-1.1.0.yaml::test_example_10
 """
 asdf_schema_tests_enabled = 'true'
 asdf_schema_ignore_unrecognized_tag = 'true'


### PR DESCRIPTION
This PR adds skips for 2 ndarray examples:
- one using an [external array](https://github.com/asdf-format/asdf-standard/blob/2764c03e1462902786d58a6b62076586c9856e84/resources/schemas/stsci.edu/asdf/core/ndarray-1.1.0.yaml#L155)
- one using a [mask](https://github.com/asdf-format/asdf-standard/blob/2764c03e1462902786d58a6b62076586c9856e84/resources/schemas/stsci.edu/asdf/core/ndarray-1.1.0.yaml#L132) that fails to round trip

The "external array" example is already partially hard-coded as a skip in the pytest plugin.
https://github.com/asdf-format/asdf/blob/6197b4c8505cdbaa1e4076566becc6af17877e89/pytest_asdf/plugin.py#L236
and we have enough external array tests in asdf to cover this example.

The "mask" example never fully worked as when read in it produces a masked array with a single "False" as the mask. When writing back out this fails (related to https://github.com/asdf-format/asdf/issues/1909). The details are:
- when read in, produces an array with `mask==False`
- when written back out this produces a tagged dict with `mask: False` which correctly fails validation

The example previously worked because the example was never deserialized.
