### PR TITLE
fix configuration for jwst downstream tests

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -38,7 +38,7 @@ jobs:
           - package_name: jwst
             repository: spacetelescope/jwst
             install_command: pip install -e .[test]
-            test_command: pytest jwst/ami -s
+            test_command: pytest
           - package_name: roman_datamodels
             repository: spacetelescope/roman_datamodels
             install_command: pip install -e .[test]


### PR DESCRIPTION
The core issue appears to be that crds or something inconsistently handles a path starting with `~`. It looks like crds downloads to a directory named `~` but then returns paths with the `~` expanded to the home directory. I'm not quite sure what's going on here (or if this ever worked) but this PR drops the `~` to work around the issue.

After poking at this a bit more I think it comes down to:
- when provided with a "~/path" CRDS treats this as a directory named "~" and downloads reference files and returns paths with that prefix
- stdatamodels treats the "~/path" as a reference to the home directory and fails to load reference files (since "/$HOME/path") doesn't exist

Fixes: https://github.com/asdf-format/asdf-standard/issues/463