### PR TITLE
Update RTD build OS from Ubuntu 20.04 to 24.04

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   apt_packages:
     - graphviz
   tools:


### PR DESCRIPTION
## Changelog
* Updated RTD build OS from Ubuntu 20.04 to 24.04
* Updated `docs/conf.py` to use `importlib_metadata` instead of `pkg_resources`