### PR TITLE
Make tests compatible with pytest `9.1`

### DIFF
--- a/tests/test_asdf_schema.py
+++ b/tests/test_asdf_schema.py
@@ -3,8 +3,10 @@ import pytest
 from asdf.exceptions import ValidationError
 from common import SCHEMAS_PATH, assert_yaml_header_and_footer, load_yaml
 
+SCHEMA_FILES = list(SCHEMAS_PATH.glob("asdf-schema-*.yaml"))
 
-@pytest.mark.parametrize("path", SCHEMAS_PATH.glob("asdf-schema-*.yaml"))
+
+@pytest.mark.parametrize("path", SCHEMA_FILES)
 def test_asdf_schema(path):
     assert_yaml_header_and_footer(path)
 
@@ -12,7 +14,7 @@ def test_asdf_schema(path):
     load_yaml(path)
 
 
-@pytest.mark.parametrize("path", SCHEMAS_PATH.glob("asdf-schema-*.yaml"))
+@pytest.mark.parametrize("path", SCHEMA_FILES)
 def test_nested_object_validation(path):
     """
     Test that the validations are applied to nested objects.

--- a/tests/test_reference_files.py
+++ b/tests/test_reference_files.py
@@ -116,7 +116,7 @@ def test_reference_files_exist():
     assert list(collect_reference_files())
 
 
-@pytest.mark.parametrize("reference_file", collect_reference_files(), ids=get_test_id)
+@pytest.mark.parametrize("reference_file", list(collect_reference_files()), ids=get_test_id)
 def test_reference_file(reference_file):
     name_without_ext, _ = os.path.splitext(reference_file)
     _compare_trees(name_without_ext)

--- a/tests/test_version_map.py
+++ b/tests/test_version_map.py
@@ -42,7 +42,7 @@ def test_version_map(path):
         assert False, message
 
 
-@pytest.mark.parametrize("path, previous_path", zip(SORTED_PATHS[1:], SORTED_PATHS[0:-1]))
+@pytest.mark.parametrize("path, previous_path", list(zip(SORTED_PATHS[1:], SORTED_PATHS[0:-1])))
 def test_version_map_tags_retained(path, previous_path):
     """
     Confirm that non-deprecated tags were not lost between

--- a/tests/test_yaml_schema.py
+++ b/tests/test_yaml_schema.py
@@ -12,7 +12,7 @@ def test_yaml_schema(path):
     load_yaml(path)
 
 
-@pytest.mark.parametrize("path", YAML_SCHEMA_PATH.glob("*.yaml"))
+@pytest.mark.parametrize("path", list(YAML_SCHEMA_PATH.glob("*.yaml")))
 def test_nested_object_validation(path):
     """
     Test that the validations are applied to nested objects.


### PR DESCRIPTION
## Description
* Updated test suite to remove usage of deprecated generator-based pytest parameterizations